### PR TITLE
Add project doctrine

### DIFF
--- a/DOCS/DOCTRINE.md
+++ b/DOCS/DOCTRINE.md
@@ -1,0 +1,27 @@
+# Project Doctrine
+
+This document summarizes the purpose and guiding philosophy of the AgentHub project and provides a short checklist for new contributors.
+
+## Goals
+
+- **Streamline AI workflows**: Provide a modular platform to orchestrate AI agents for startups.
+- **Observability and reliability**: Offer built‑in monitoring, logging and health checks.
+- **Extensibility**: Allow teams to create new agents and workflows with minimal boilerplate.
+
+## Core Principles
+
+1. **Modular design** – Agents should have clear, single responsibilities.
+2. **Configuration as code** – Workflows and settings live in version control.
+3. **Deterministic orchestration** – Workflows should be predictable and reproducible.
+4. **Open standards** – Interoperability with A2A, MCP and ACP protocols.
+5. **Quality first** – Tests and linting are mandatory before merging.
+
+## Contributor Guidelines
+
+- Fork the repository and create feature branches for all changes.
+- Follow the coding style enforced by `black`, `flake8` and `isort`.
+- Add unit tests for new features and run `pytest` before submitting a pull request.
+- Keep documentation up to date when behaviour or interfaces change.
+- Be descriptive in commit messages and pull request descriptions.
+
+Welcome to the community!

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 AgentHub es un framework modular que permite crear, coordinar y escalar agentes de inteligencia artificial para automatizar flujos de trabajo complejos.
 
+Consulta la [doctrina del proyecto](DOCS/DOCTRINE.md) para conocer los principios fundamentales.
 ## 🌟 Características
 
 - **🏗️ Arquitectura Modular**: Agentes independientes con responsabilidades específicas


### PR DESCRIPTION
## Summary
- document core goals and contributor guidance in DOCS/DOCTRINE.md
- link to doctrine from README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi' and 'agenthub')*

------
https://chatgpt.com/codex/tasks/task_e_687b3a7511e48325a349eefea71f7ffb