### PR TITLE
Fix CLI echo formatting

### DIFF
--- a/back/agenthub/cli.py
+++ b/back/agenthub/cli.py
@@ -192,9 +192,9 @@ class ExampleAgent(BaseAgent):
         )
 
     click.echo(f"✅ Project {project_name} created successfully!")
-    click.echo(f"📁 Next steps:")
+    click.echo("📁 Next steps:")
     click.echo(f"   cd {project_name}")
-    click.echo(f"   agenthub-server")
+    click.echo("   agenthub-server")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remove `f` prefixes from cli strings that don't use placeholders

## Testing
- `pre-commit run --files back/agenthub/cli.py` *(fails: pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687bc67462b8832585e7fd1fa78fa68c