### PR TITLE
Allow optional timeout in workflow registration

### DIFF
--- a/back/agenthub/orchestrator.py
+++ b/back/agenthub/orchestrator.py
@@ -88,8 +88,12 @@ class Orchestrator:
         self.agent_registry.register(agent)
 
     def register_workflow(
-        self, name: str, tasks: List[str], parallel: bool = False, timeout: int = None
-    ):
+        self,
+        name: str,
+        tasks: List[str],
+        parallel: bool = False,
+        timeout: Optional[int] = None,
+    ) -> None:
         """
         Registra un workflow
 


### PR DESCRIPTION
## Summary
- let `register_workflow` accept an Optional timeout
- call `register_workflow` in API with `Optional[int]`

## Testing
- `mypy back/agenthub/orchestrator.py back/agenthub/main.py` *(fails: missing stubs)*
- `pre-commit run --files back/agenthub/orchestrator.py back/agenthub/main.py` *(fails: pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687bc67755bc832596bc20b3f6bcd767