### PR TITLE
Load default workflows during startup

### DIFF
--- a/back/agenthub/main.py
+++ b/back/agenthub/main.py
@@ -92,7 +92,9 @@ async def startup_event():
 
         # Importar workflows predefinidos
         try:
-            pass
+            from agenthub.workflows.default import register_default_workflows
+
+            register_default_workflows()
 
             logger.info("Default workflows loaded")
         except ImportError as e:


### PR DESCRIPTION
## Summary
- load default workflows when AgentHub starts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'uvicorn')*

------
https://chatgpt.com/codex/tasks/task_e_687dac4b085c8325ad2abe049f72d067