### PR TITLE
Add workflow task validation

### DIFF
--- a/back/agenthub/main.py
+++ b/back/agenthub/main.py
@@ -344,6 +344,13 @@ async def get_workflow(workflow_name: str):
 async def register_workflow(request: WorkflowDefinitionRequest):
     """Registra un nuevo workflow"""
     try:
+        for task in request.tasks:
+            if not orchestrator.is_valid_task(task):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Invalid task format: {task}. Use 'agent_id.action'",
+                )
+
         orchestrator.register_workflow(
             name=request.name,
             tasks=request.tasks,
@@ -357,6 +364,8 @@ async def register_workflow(request: WorkflowDefinitionRequest):
             "tasks": request.tasks,
         }
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Error registering workflow: {e}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/back/agenthub/orchestrator.py
+++ b/back/agenthub/orchestrator.py
@@ -1,5 +1,6 @@
 # agenthub/orchestrator.py
 import logging
+import re
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
@@ -76,6 +77,14 @@ class WorkflowRegistry:
 class Orchestrator:
     """Orquestador central de AgentHub"""
 
+    # Patrón para validar tareas en formato "agente.accion"
+    TASK_REGEX = re.compile(r"^[^.]+\.[^.]+$")
+
+    @classmethod
+    def is_valid_task(cls, task: str) -> bool:
+        """Valida que la tarea tenga formato 'agent_id.action'."""
+        return bool(cls.TASK_REGEX.match(task))
+
     def __init__(self):
         self.agent_registry = AgentRegistry()
         self.workflow_registry = WorkflowRegistry()
@@ -103,6 +112,12 @@ class Orchestrator:
             parallel: Si las tareas se ejecutan en paralelo
             timeout: Timeout en segundos
         """
+        for task in tasks:
+            if not self.is_valid_task(task):
+                raise ValueError(
+                    f"Invalid task format: {task}. Use 'agent_id.action'"
+                )
+
         definition = {
             "tasks": tasks,
             "parallel": parallel,


### PR DESCRIPTION
## Summary
- validate incoming workflow tasks in API
- ensure orchestrator checks task format using regex

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'uvicorn')*
- `pre-commit run --files back/agenthub/main.py back/agenthub/orchestrator.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687dac4c98dc8325be34cf9f0f6fbd30