### PR TITLE
Improve missing agent error messages

### DIFF
--- a/back/agenthub/main.py
+++ b/back/agenthub/main.py
@@ -309,6 +309,7 @@ async def send_message(request: MessageRequest):
         }
 
     except ValueError as e:
+        # Propagar mensaje detallado del orquestador
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
         logger.error(f"Error sending message: {e}")

--- a/back/agenthub/orchestrator.py
+++ b/back/agenthub/orchestrator.py
@@ -36,7 +36,14 @@ class AgentRegistry:
 
     def get(self, agent_id: str) -> Optional[BaseAgent]:
         """Obtiene un agente por ID"""
-        return self.agents.get(agent_id)
+        agent = self.agents.get(agent_id)
+        if not agent:
+            self.logger.debug(
+                "Agent %s not found. Available agents: %s",
+                agent_id,
+                ", ".join(self.list_agents()) or "none",
+            )
+        return agent
 
     def list_agents(self) -> List[str]:
         """Lista todos los agentes registrados"""
@@ -114,7 +121,10 @@ class Orchestrator:
         """Envía un mensaje a un agente específico"""
         agent = self.agent_registry.get(agent_id)
         if not agent:
-            raise ValueError(f"Agent {agent_id} not found")
+            available = ", ".join(self.agent_registry.list_agents()) or "none"
+            raise ValueError(
+                f"Agent {agent_id} not found. Available agents: {available}"
+            )
 
         return agent.process_message(message)
 

--- a/back/tests/integration/test_api.py
+++ b/back/tests/integration/test_api.py
@@ -57,3 +57,11 @@ class TestAPI:
         assert response.status_code == 200
         data = response.json()
         assert "execution_id" in data
+
+    def test_send_message_unknown_agent(self, client):
+        message_data = {"agent_id": "ghost", "action": "test"}
+        response = client.post("/message/send", json=message_data)
+        assert response.status_code == 404
+        data = response.json()
+        assert "ghost" in data["detail"]
+        assert "Available agents" in data["detail"]

--- a/back/tests/unit/test_orchestrator.py
+++ b/back/tests/unit/test_orchestrator.py
@@ -1,3 +1,4 @@
+import pytest
 from agenthub.agents.base_agent import BaseAgent
 from agenthub.orchestrator import AgentRegistry, Orchestrator, WorkflowRegistry
 
@@ -58,6 +59,15 @@ class TestOrchestrator:
         )
 
         assert result["status"] == "success"
+
+    def test_send_message_unknown_agent(self):
+        orchestrator = Orchestrator()
+
+        with pytest.raises(ValueError) as exc:
+            orchestrator.send_message("ghost", {"action": "test"})
+
+        assert "ghost" in str(exc.value)
+        assert "Available agents" in str(exc.value)
 
     def test_execute_workflow(self):
         orchestrator = Orchestrator()


### PR DESCRIPTION
## Summary
- include available agent IDs when fetching unknown agent
- surface error messages in `/message/send` endpoint
- test missing agent error handling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'uvicorn')*

------
https://chatgpt.com/codex/tasks/task_e_687dac4d747883259a6d5af4e0802291