### PR TITLE
Fix doctrine link in backend README

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -20,7 +20,7 @@ AgentHub is a lightweight framework for coordinating AI agents. It exposes a RES
 
 ## Running the server
 
-Consulta la [doctrina del proyecto](DOCS/DOCTRINE.md) para conocer los principios fundamentales.
+Consulta la [doctrina del proyecto](docs/DOCTRINE.md) para conocer los principios fundamentales.
 ## 🌟 Características
 
 - **🏗️ Arquitectura Modular**: Agentes independientes con responsabilidades específicas


### PR DESCRIPTION
## Summary
- fix path to `docs/DOCTRINE.md` in backend README

## Testing
- `pytest` *(fails: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_687dc80860a48325aa2eaa74258f2739