### PR TITLE
Update test paths

### DIFF
--- a/back/Makefile
+++ b/back/Makefile
@@ -15,7 +15,7 @@ install: ## Instalar dependencias
 	pre-commit install
 
 test: ## Ejecutar tests
-	pytest agenthub/tests/ -v --cov=agenthub
+        pytest tests/ -v --cov=agenthub
 
 lint: ## Verificar código
 	flake8 agenthub/

--- a/back/pytest.ini
+++ b/back/pytest.ini
@@ -1,5 +1,5 @@
 [tool:pytest]
-testpaths = agenthub/tests
+testpaths = tests
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*


### PR DESCRIPTION
## Summary
- point pytest to `tests/`
- adjust Makefile `pytest` target accordingly

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_687dc807b9cc8325a83de66eb30ebc26