### PR TITLE
Fix import for backend agent

### DIFF
--- a/back/agenthub/agents/backend_agent.py
+++ b/back/agenthub/agents/backend_agent.py
@@ -1,5 +1,5 @@
 # agenthub/agents/backend_agent.py
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
 
 from .base_agent import BaseAgent
 


### PR DESCRIPTION
## Summary
- import `List` and `Optional` in the backend agent

## Testing
- `isort back/agenthub/agents/backend_agent.py`
- `black back/agenthub/agents/backend_agent.py`
- `mypy back/agenthub/agents/backend_agent.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_687dc8068c248325a87e524f555b804f