### PR TITLE
Implement missing agent and task handlers

### DIFF
--- a/back/agenthub/agents/fastapi_generator_agent.py
+++ b/back/agenthub/agents/fastapi_generator_agent.py
@@ -1,0 +1,56 @@
+from typing import Any, Dict, List, Optional
+from .base_agent import BaseAgent
+
+
+class FastAPIGeneratorAgent(BaseAgent):
+    """Agente que genera código base de FastAPI como endpoints CRUD."""
+
+    def __init__(self) -> None:
+        super().__init__("fastapi_generator", "FastAPI Code Generator")
+
+    def get_capabilities(self) -> Dict[str, Any]:
+        return {
+            "actions": ["generate_crud_endpoint"],
+            "description": "Genera código FastAPI automáticamente",
+        }
+
+    def handle(self, message: Dict[str, Any]) -> Dict[str, Any]:
+        action = message.get("action")
+        data = message.get("data", {})
+
+        if action == "generate_crud_endpoint":
+            return self._generate_crud_endpoint(data)
+
+        return {"status": "error", "error": f"Acción '{action}' no reconocida"}
+
+    def _generate_crud_endpoint(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        model_name: str = data.get("model_name", "Item")
+        fields: List[Dict[str, Any]] = data.get("fields", [])
+        include_auth: bool = data.get("include_auth", False)
+
+        model_lines = [f"class {model_name}(BaseModel):"]
+        for field in fields:
+            field_name = field.get("name", "field")
+            field_type = field.get("type", "str")
+            optional = field.get("optional", False)
+            if optional:
+                model_lines.append(f"    {field_name}: Optional[{field_type}] = None")
+            else:
+                model_lines.append(f"    {field_name}: {field_type}")
+
+        model_code = "\n".join(model_lines)
+
+        endpoint_code = f"""
+@app.post('/{model_name.lower()}s/', response_model={model_name})
+def create_{model_name.lower()}(item: {model_name}):
+    {'# TODO: validate auth\n    ' if include_auth else ''}return item
+"""
+
+        return {
+            "status": "success",
+            "data": {
+                "files_created": [f"{model_name.lower()}.py"],
+                "model_code": model_code,
+                "endpoint_code": endpoint_code,
+            },
+        }

--- a/back/agenthub/agents/test_generator_agent.py
+++ b/back/agenthub/agents/test_generator_agent.py
@@ -13,7 +13,8 @@ class TestGeneratorAgent(BaseAgent):
                 "generate_unit_tests",
                 "generate_api_tests",
                 "generate_load_tests",
-                "create_test_data"
+                "create_test_data",
+                "generate_security_tests"
             ],
             "description": "Genera tests automáticamente para APIs y código"
         }
@@ -26,6 +27,8 @@ class TestGeneratorAgent(BaseAgent):
             return self._generate_api_tests(data)
         elif action == "generate_unit_tests":
             return self._generate_unit_tests(data)
+        elif action == "generate_security_tests":
+            return self._generate_security_tests(data)
         else:
             return {"status": "error", "error": f"Acción '{action}' no reconocida"}
     
@@ -77,4 +80,25 @@ def test_{method}_{endpoint_path.replace("/", "_").replace("{", "").replace("}",
                 "unit_tests": f"Generated {len(functions)} unit tests",
                 "coverage_target": "80%"
             }
+        }
+
+    def _generate_security_tests(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        """Genera pruebas básicas de seguridad para endpoints."""
+        endpoints = data.get("endpoints", [])
+        tests = []
+        for endpoint in endpoints:
+            path = endpoint.get("path", "/")
+            method = endpoint.get("method", "GET").lower()
+            test = f"""def test_{method}_{path.replace('/', '_').replace('{','').replace('}','')}_auth_required(client):\n    response = client.{method}("{path}")\n    assert response.status_code == 401\n"""
+            tests.append(test)
+
+        test_file = "import pytest\nfrom fastapi.testclient import TestClient\nfrom main import app\n\nclient = TestClient(app)\n\n" + "\n".join(tests)
+
+        return {
+            "status": "success",
+            "data": {
+                "test_code": test_file,
+                "test_file": "test_security.py",
+                "tests_generated": len(tests),
+            },
         }


### PR DESCRIPTION
## Summary
- add missing `FastAPIGeneratorAgent` to satisfy registry
- extend `TestGeneratorAgent` with `generate_security_tests` action

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_687dc80632e883259839ad3b757ae2f4