### PR TITLE
Remove enterprise shell reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,20 +542,6 @@ curl http://localhost:8000/health
 curl http://localhost:3000
 ```
 
-### 🏢 Modo Enterprise
-
-```bash
-# Activar características enterprise
-cd front
-./start-enterprise.sh
-
-# Características activadas:
-# ✅ WebSocket real-time
-# ✅ Analytics avanzado
-# ✅ Error tracking
-# ✅ 4 temas profesionales
-# ✅ Métricas de performance
-```
 
 ---
 


### PR DESCRIPTION
## Summary
- remove reference to nonexistent `start-enterprise.sh` in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pre-commit run --files README.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687dc9b423488325bb1c688ad2b488fc