### PR TITLE
Fix frontend lock file version mismatches

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -16,9 +16,9 @@
       },
       "devDependencies": {
         "@tailwindcss/line-clamp": "^0.4.4",
-        "autoprefixer": "^10.4.21",
-        "postcss": "^8.5.6",
-        "tailwindcss": "^4.1.11"
+        "autoprefixer": "^10.4.14",
+        "postcss": "^8.4.24",
+        "tailwindcss": "^3.3.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -5798,8 +5798,8 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.21",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
+      "version": "10.4.14",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.14.tgz",
       "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
       "funding": [
         {
@@ -13757,8 +13757,8 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "version": "8.4.24",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
       "funding": [
         {
@@ -17848,8 +17848,8 @@
       "license": "MIT"
     },
     "node_modules/tailwindcss": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.11.tgz",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.0.tgz",
       "integrity": "sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==",
       "dev": true,
       "license": "MIT"


### PR DESCRIPTION
## Summary
- update front/package-lock.json to match versions in package.json

## Testing
- `pre-commit run --files front/package-lock.json` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687dc9b460dc832580b76d6213331952