### PR TITLE
Add PyYAML dependency

### DIFF
--- a/back/requirements.txt
+++ b/back/requirements.txt
@@ -1,6 +1,7 @@
 fastapi>=0.115.1
 requests
 types-requests
+PyYAML>=6.0
 
 # Compatibilidad con Kubernetes
 urllib3<2.0


### PR DESCRIPTION
## Summary
- add `PyYAML>=6.0` to `back/requirements.txt`

## Testing
- `pytest -q` *(fails: No module named 'yaml', 'uvicorn')*

------
https://chatgpt.com/codex/tasks/task_e_687eab9f42088325a8a45708bc40954b