### PR TITLE
Fix logging usage in config

### DIFF
--- a/back/agenthub/config.py
+++ b/back/agenthub/config.py
@@ -1,9 +1,12 @@
 # agenthub/config.py
 import os
+import logging
 from pathlib import Path
 from typing import Any, Dict
 
 import yaml
+
+logger = logging.getLogger(__name__)
 
 
 class Config:
@@ -23,7 +26,7 @@ class Config:
             with open(self.config_path, "r", encoding="utf-8") as f:
                 return yaml.safe_load(f) or {}
         except Exception as e:
-            print(f"Error loading config file {self.config_path}: {e}")
+            logger.error("Error loading config file %s: %s", self.config_path, e)
             return {}
 
     def _apply_defaults(self):


### PR DESCRIPTION
## Summary
- replace print() with logger.error() in `agenthub/config.py`
- configure module logger

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_687eaba0581c83259ca18b64ee3c743b