### PR TITLE
Fix endpoint_code generation

### DIFF
--- a/back/agenthub/agents/fastapi_generator_agent.py
+++ b/back/agenthub/agents/fastapi_generator_agent.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, List, Optional
+
 from .base_agent import BaseAgent
 
 
@@ -40,11 +41,14 @@ class FastAPIGeneratorAgent(BaseAgent):
 
         model_code = "\n".join(model_lines)
 
-        endpoint_code = f"""
-@app.post('/{model_name.lower()}s/', response_model={model_name})
-def create_{model_name.lower()}(item: {model_name}):
-    {'# TODO: validate auth\n    ' if include_auth else ''}return item
-"""
+        endpoint_lines = [
+            f"@app.post('/{model_name.lower()}s/', response_model={model_name})",
+            f"def create_{model_name.lower()}(item: {model_name}):",
+        ]
+        if include_auth:
+            endpoint_lines.append("    # TODO: validate auth")
+        endpoint_lines.append("    return item")
+        endpoint_code = "\n".join(endpoint_lines)
 
         return {
             "status": "success",


### PR DESCRIPTION
## Summary
- refactor FastAPIGeneratorAgent to build endpoint_code without `\n`

## Testing
- `mypy back/agenthub/agents/fastapi_generator_agent.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_687eaba0a9108325ba14dbeed5335224