### PR TITLE
Fix registry format

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -73,6 +73,18 @@ curl -X POST http://localhost:8000/message/send \
   -d '{"agent_id":"backend_agent","action":"analyze_requirements","data":{"requirements":"Simple API"}}'
 ```
 
+## Agent registry
+
+Agents are loaded from `registry.json` on startup. The file must contain a list
+of objects with `id`, `class` and optional `config` fields:
+
+```json
+[
+  {"id": "backend_agent", "class": "BackendAgent", "config": {}},
+  {"id": "qa_agent", "class": "QAAgent", "config": {}}
+]
+```
+
 ## Development commands
 
 Use the supplied `Makefile` for common tasks:

--- a/back/registry.json
+++ b/back/registry.json
@@ -1,75 +1,12 @@
-{
-  "agents": {
-    "fastapi_generator": {
-      "name": "FastAPI Code Generator",
-      "module": "agenthub.agents.fastapi_generator_agent",
-      "class": "FastAPIGeneratorAgent",
-      "description": "Genera código FastAPI automáticamente",
-      "category": "backend_development",
-      "version": "1.0.0",
-      "enabled": true
-    },
-    "database_architect": {
-      "name": "Database Architect",
-      "module": "agenthub.agents.database_architect_agent", 
-      "class": "DatabaseArchitectAgent",
-      "description": "Diseña y optimiza arquitectura de base de datos",
-      "category": "database",
-      "version": "1.0.0",
-      "enabled": true
-    },
-    "test_generator": {
-      "name": "Test Generator",
-      "module": "agenthub.agents.test_generator_agent",
-      "class": "TestGeneratorAgent", 
-      "description": "Genera tests automáticamente",
-      "category": "testing",
-      "version": "1.0.0",
-      "enabled": true
-    },
-    "security_auditor": {
-      "name": "Security Auditor",
-      "module": "agenthub.agents.security_auditor_agent",
-      "class": "SecurityAuditorAgent",
-      "description": "Realiza auditorías de seguridad",
-      "category": "security", 
-      "version": "1.0.0",
-      "enabled": true
-    },
-    "api_documentator": {
-      "name": "API Documentator",
-      "module": "agenthub.agents.api_documentator_agent",
-      "class": "APIDocumentatorAgent",
-      "description": "Genera documentación automática",
-      "category": "documentation",
-      "version": "1.0.0", 
-      "enabled": true
-    }
+[
+  {
+    "id": "backend_agent",
+    "class": "BackendAgent",
+    "config": {}
   },
-  "workflows": {
-    "backend_development": {
-      "name": "Backend Development Complete",
-      "description": "Desarrollo completo de backend desde cero",
-      "tasks": [
-        "database_architect.design_schema",
-        "fastapi_generator.generate_crud_endpoint",
-        "test_generator.generate_api_tests",
-        "security_auditor.scan_vulnerabilities",
-        "api_documentator.generate_openapi_spec"
-      ],
-      "enabled": true
-    },
-    "api_security_audit": {
-      "name": "API Security Audit",
-      "description": "Auditoría completa de seguridad de API",
-      "tasks": [
-        "security_auditor.scan_vulnerabilities",
-        "security_auditor.check_auth_security",
-        "test_generator.generate_security_tests"
-      ],
-      "enabled": true
-    }
-  },
-  "version": "2.0.0",
-  "last_updated": "2024-01-01T00:00:00Z"
-}
+  {
+    "id": "qa_agent",
+    "class": "QAAgent",
+    "config": {}
+  }
+]


### PR DESCRIPTION
## Summary
- simplify `registry.json` to match `load_agents_from_registry`
- document registry format in the backend README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_687eaba1272483259af12d6dce73bd6d