### PR TITLE
Refactor DB connection logging

### DIFF
--- a/back/agenthub/database/connection.py
+++ b/back/agenthub/database/connection.py
@@ -1,30 +1,31 @@
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker, declarative_base
-from sqlalchemy.orm import declarative_base
-from sqlalchemy import create_engine
-from sqlalchemy.orm import Session
-from contextlib import contextmanager
+import logging
 import os
+
 from dotenv import load_dotenv
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
 load_dotenv()
 
 
+logger = logging.getLogger(__name__)
 
 DATABASE_URL = os.getenv("DATABASE_URL")
-
+if not DATABASE_URL:
+    raise RuntimeError("DATABASE_URL environment variable not set")
 
 if " " in DATABASE_URL:
-    print("Hay un espacio invisible")
-    print("🧪 DATABASE_URL:", DATABASE_URL)
+    logger.debug("DATABASE_URL contains whitespace: %s", DATABASE_URL)
 
 engine = create_engine(DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()
 
+
 def get_db():
+    logger.info("Connecting to database")
     db = SessionLocal()
     try:
-        print("Conectando a la base de datos...")
         yield db
     finally:
         db.close()


### PR DESCRIPTION
## Summary
- clean up imports for DB connection
- validate `DATABASE_URL`
- switch print statements to logger calls
- log when establishing DB connection

## Testing
- `isort back/agenthub/database/connection.py`
- `black back/agenthub/database/connection.py`
- `mypy back/agenthub/database/connection.py` *(fails: missing stubs)*
- `flake8 back/agenthub/database/connection.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881b848b2f883259bdc206ec67fae0c