### PR TITLE
Remove duplicate table creation script

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -17,6 +17,11 @@ AgentHub is a lightweight framework for coordinating AI agents. It exposes a RES
    ```
    You can also run `make install` if you have `make` available.
 
+3. Initialize the database tables
+   ```bash
+   python -m agenthub.database.create_tables
+   ```
+
 
 ## Running the server
 

--- a/back/agenthub/create_tables.py
+++ b/back/agenthub/create_tables.py
@@ -1,9 +1,0 @@
-from agenthub.database.connection import engine, Base
-from agenthub.models.user import User
-
-def create_tables():
-    Base.metadata.create_all(bind=engine)
-    print("✅ Tablas creadas exitosamente")
-
-if __name__ == "__main__":
-    create_tables()


### PR DESCRIPTION
## Summary
- remove duplicate `create_tables.py` and keep the one in `agenthub/database`
- document how to initialize database tables in `back/README.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy, yaml, uvicorn)*

------
https://chatgpt.com/codex/tasks/task_e_6881b84997c483258edc97d6dd38f4c7