### PR TITLE
Update frontend to use API env var

### DIFF
--- a/front/README.md
+++ b/front/README.md
@@ -239,6 +239,14 @@ npm test -- --coverage
 
 ### Variables de Entorno
 
+Las siguientes variables controlan la configuración del frontend. Al menos
+`REACT_APP_API_URL` es necesaria para que la aplicación conozca la URL base de la
+API.
+
+| Variable            | Descripción                                   |
+|---------------------|-----------------------------------------------|
+| `REACT_APP_API_URL` | URL base del backend utilizado por el frontend |
+
 #### Desarrollo
 ```bash
 REACT_APP_ENV=development

--- a/front/src/api/auth.js
+++ b/front/src/api/auth.js
@@ -1,4 +1,6 @@
-const API_URL = "http://localhost:8000/auth";
+// Base URL for the authentication endpoints
+// Defaults to localhost for development if the env variable is not provided
+const API_URL = `${process.env.REACT_APP_API_URL || 'http://localhost:8000'}/auth`;
 
 export async function loginRequest(email, password) {
   const res = await fetch(`${API_URL}/signin`, {

--- a/front/src/context/AuthContext.jsx
+++ b/front/src/context/AuthContext.jsx
@@ -1,6 +1,6 @@
 // src/context/AuthContext.jsx
 import { createContext, useContext, useState } from 'react';
-import { loginService } from "../services/auth.service";
+import { loginRequest } from "../api/auth";
 
 const AuthContext = createContext();
 
@@ -11,23 +11,17 @@ export const AuthProvider = ({ children }) => {
 
   const login = async (email, password) => {
     try {
-      const response = await fetch('http://localhost:8000/auth/signin', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, password })
-      });
-      
-      const data = await response.json();
-      
-      if (response.ok) {
+      const data = await loginRequest(email, password);
+
+      if (data.access_token) {
         setToken(data.access_token);
         localStorage.setItem('token', data.access_token);
         setIsLoggedIn(true);
         setUser(data.user);
         return { success: true };
-      } else {
-        return { success: false, error: data.detail };
       }
+
+      return { success: false, error: data.detail };
     } catch (error) {
       return { success: false, error: 'Error de conexión' };
     }

--- a/front/src/utils/api.ts
+++ b/front/src/utils/api.ts
@@ -1,7 +1,8 @@
 // utils/api.ts o directamente dentro de tu componente
 export async function loginUser(email: string, password: string) {
+  const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:8000';
   try {
-    const response = await fetch("http://localhost:8000/auth/signin", {
+    const response = await fetch(`${API_BASE_URL}/auth/signin`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- use `REACT_APP_API_URL` in auth API module
- rely on `loginRequest` in auth context
- parameterize helper login API
- document environment variables in README

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881b84b188483258a32396b23bb778c