### PR TITLE
Handle unknown agent errors

### DIFF
--- a/back/agenthub/main.py
+++ b/back/agenthub/main.py
@@ -172,6 +172,8 @@ async def send_message(req: MessageRequest):
             req.agent_id, {"action": req.action, "data": req.data}
         )
         return {"result": result}
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 


### PR DESCRIPTION
## Summary
- return 404 for unknown agents

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6881b84bd4288325b3856e00da3d7932