### PR TITLE
Add auth injection to FastAPI generator

### DIFF
--- a/back/tests/unit/agents/test_fastapi_generator_agent.py
+++ b/back/tests/unit/agents/test_fastapi_generator_agent.py
@@ -1,0 +1,18 @@
+import pytest
+from agenthub.agents.fastapi_generator_agent import FastAPIGeneratorAgent
+
+
+def test_generate_crud_endpoint_with_auth():
+    agent = FastAPIGeneratorAgent()
+    message = {
+        "action": "generate_crud_endpoint",
+        "data": {
+            "model_name": "Item",
+            "fields": [{"name": "name", "type": "str"}],
+            "include_auth": True,
+        },
+    }
+    result = agent.process_message(message)
+    assert result["status"] == "success"
+    endpoint_code = result["data"]["endpoint_code"]
+    assert "Depends(oauth2_scheme)" in endpoint_code


### PR DESCRIPTION
## Summary
- update `fastapi_generator_agent` to add OAuth2 auth when generating CRUD endpoints
- add unit test for auth injection

## Testing
- `PYTHONPATH=back pytest back/tests/unit/agents/test_fastapi_generator_agent.py -q`
- `PYTHONPATH=back pytest back/tests/unit -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6882ecdef0b883258ba7afa5a0dbbecf