### PR TITLE
Add simple workflow engine and endpoints

### DIFF
--- a/back/agenthub/main.py
+++ b/back/agenthub/main.py
@@ -40,6 +40,7 @@ from agenthub.database.connection import SessionLocal, engine, Base
 
 # 6. ¡POR ÚLTIMO!: Import de oauth (DESPUÉS de load_dotenv)
 from agenthub.auth.oauth_routes import router as oauth_router
+from api.workflows import router as workflows_router
 
 # Logging
 logging.basicConfig(
@@ -181,6 +182,7 @@ app.add_middleware(
 
 # Include auth routes
 app.include_router(auth_router, prefix="/auth", tags=["authentication"])
+app.include_router(workflows_router, prefix="/workflows", tags=["workflows"])
 
 # ============================================
 # PYDANTIC MODELS

--- a/back/api/__init__.py
+++ b/back/api/__init__.py
@@ -1,0 +1,1 @@
+"""API package for routers."""

--- a/back/api/workflows.py
+++ b/back/api/workflows.py
@@ -1,0 +1,84 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from typing import Any, Dict, List, Optional
+
+from workflow_engine import (
+    WorkflowEngine,
+    Workflow,
+    WorkflowNode,
+    WorkflowConnection,
+    ConnectionType,
+    AgentRegistry,
+    EventBus,
+)
+
+
+router = APIRouter()
+
+# Simple global engine
+agent_registry = AgentRegistry()
+event_bus = EventBus()
+engine = WorkflowEngine(agent_registry, event_bus)
+
+
+class NodeModel(BaseModel):
+    id: str
+    agent_type: str
+    config: Dict[str, Any] = {}
+
+
+class ConnectionModel(BaseModel):
+    source_id: str
+    target_id: str
+    type: ConnectionType = ConnectionType.SUCCESS
+
+
+class WorkflowCreate(BaseModel):
+    id: str
+    name: str
+    nodes: List[NodeModel]
+    connections: List[ConnectionModel] = []
+
+
+class ExecutionRequest(BaseModel):
+    data: Optional[Dict[str, Any]] = None
+
+
+@router.get("/")
+async def list_workflows():
+    return {"workflows": list(engine.workflows.keys())}
+
+
+@router.post("/")
+async def create_workflow(defn: WorkflowCreate):
+    wf = Workflow(defn.id, defn.name)
+    for node in defn.nodes:
+        wf.add_node(WorkflowNode(node.id, node.agent_type, node.config))
+    for conn in defn.connections:
+        wf.add_connection(
+            WorkflowConnection(conn.source_id, conn.target_id, conn.type)
+        )
+    engine.register_workflow(wf)
+    return {"workflow_id": wf.id}
+
+
+@router.get("/{workflow_id}")
+async def get_workflow(workflow_id: str):
+    wf = engine.get_workflow(workflow_id)
+    if not wf:
+        raise HTTPException(status_code=404, detail="Workflow not found")
+    return {
+        "id": wf.id,
+        "name": wf.name,
+        "nodes": [vars(n) for n in wf.nodes.values()],
+        "connections": [vars(c) for c in wf.connections],
+    }
+
+
+@router.post("/{workflow_id}/run")
+async def run_workflow(workflow_id: str, req: ExecutionRequest):
+    try:
+        result = await engine.execute(workflow_id, req.data)
+        return {"result": result}
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))

--- a/back/tests/unit/test_workflow_engine.py
+++ b/back/tests/unit/test_workflow_engine.py
@@ -1,0 +1,48 @@
+import pytest
+
+from workflow_engine import (
+    WorkflowEngine,
+    Workflow,
+    WorkflowNode,
+    WorkflowConnection,
+    AgentRegistry,
+    EventBus,
+    ConnectionType,
+)
+
+
+class DummyAgent:
+    async def handle(self, message):
+        return {"echo": message.get("data")}
+
+
+@pytest.fixture
+def engine():
+    registry = AgentRegistry()
+    registry.register_agent("dummy", DummyAgent())
+    bus = EventBus()
+    return WorkflowEngine(registry, bus)
+
+
+@pytest.mark.asyncio
+async def test_workflow_creation_and_execution(engine):
+    wf = Workflow("wf1", "Test")
+    wf.add_node(WorkflowNode("n1", "dummy", {}))
+    engine.register_workflow(wf)
+
+    assert engine.get_workflow("wf1") is wf
+
+    result = await engine.execute("wf1", {"value": 1})
+    assert result["n1"]["echo"] == {"value": 1}
+
+
+@pytest.mark.asyncio
+async def test_sequential_execution(engine):
+    wf = Workflow("wf2", "Chain")
+    wf.add_node(WorkflowNode("a", "dummy"))
+    wf.add_node(WorkflowNode("b", "dummy"))
+    wf.add_connection(WorkflowConnection("a", "b", ConnectionType.SUCCESS))
+
+    engine.register_workflow(wf)
+    result = await engine.execute("wf2", {"x": 2})
+    assert list(result.keys()) == ["a", "b"]

--- a/back/workflow_engine/__init__.py
+++ b/back/workflow_engine/__init__.py
@@ -1,0 +1,19 @@
+from .engine import (
+    WorkflowEngine,
+    Workflow,
+    WorkflowNode,
+    WorkflowConnection,
+    AgentRegistry,
+    EventBus,
+    ConnectionType,
+)
+
+__all__ = [
+    "WorkflowEngine",
+    "Workflow",
+    "WorkflowNode",
+    "WorkflowConnection",
+    "AgentRegistry",
+    "EventBus",
+    "ConnectionType",
+]

--- a/back/workflow_engine/engine.py
+++ b/back/workflow_engine/engine.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional
+
+
+class ConnectionType(Enum):
+    SUCCESS = "success"
+    ERROR = "error"
+
+
+@dataclass
+class WorkflowNode:
+    id: str
+    agent_type: str
+    config: Dict[str, Any] = field(default_factory=dict)
+    inputs: List[str] = field(default_factory=list)
+
+
+@dataclass
+class WorkflowConnection:
+    source_id: str
+    target_id: str
+    type: ConnectionType = ConnectionType.SUCCESS
+
+
+class Workflow:
+    def __init__(self, workflow_id: str, name: str) -> None:
+        self.id = workflow_id
+        self.name = name
+        self.nodes: Dict[str, WorkflowNode] = {}
+        self.connections: List[WorkflowConnection] = []
+
+    def add_node(self, node: WorkflowNode) -> None:
+        self.nodes[node.id] = node
+
+    def add_connection(self, connection: WorkflowConnection) -> None:
+        self.connections.append(connection)
+        target = self.nodes.get(connection.target_id)
+        if target:
+            target.inputs.append(connection.source_id)
+
+
+class AgentRegistry:
+    def __init__(self) -> None:
+        self._agents: Dict[str, Any] = {}
+
+    def register_agent(self, agent_type: str, agent: Any) -> None:
+        self._agents[agent_type] = agent
+
+    def get_agent(self, agent_type: str) -> Any:
+        return self._agents.get(agent_type)
+
+
+class EventBus:
+    def __init__(self) -> None:
+        self._listeners: Dict[str, List[Callable[[Any], Any]]] = {}
+
+    def subscribe(self, event: str, callback: Callable[[Any], Any]) -> None:
+        self._listeners.setdefault(event, []).append(callback)
+
+    async def emit(self, event: str, data: Any) -> None:
+        for cb in self._listeners.get(event, []):
+            result = cb(data)
+            if asyncio.iscoroutine(result):
+                await result
+
+
+class WorkflowEngine:
+    def __init__(self, registry: AgentRegistry, event_bus: EventBus) -> None:
+        self.registry = registry
+        self.event_bus = event_bus
+        self.workflows: Dict[str, Workflow] = {}
+
+    def register_workflow(self, workflow: Workflow) -> None:
+        self.workflows[workflow.id] = workflow
+
+    def get_workflow(self, workflow_id: str) -> Optional[Workflow]:
+        return self.workflows.get(workflow_id)
+
+    async def execute(self, workflow_id: str, data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        workflow = self.get_workflow(workflow_id)
+        if not workflow:
+            raise ValueError("Workflow not found")
+        return await self._run_workflow(workflow, data or {})
+
+    async def _run_workflow(self, workflow: Workflow, context: Dict[str, Any]) -> Dict[str, Any]:
+        order = self._topological_sort(workflow)
+        results: Dict[str, Any] = {}
+        for node_id in order:
+            node = workflow.nodes[node_id]
+            agent = self.registry.get_agent(node.agent_type)
+            if not agent:
+                raise ValueError(f"Agent {node.agent_type} not registered")
+            message = {"action": node.config.get("action", "run"), "data": context}
+            result = await agent.handle(message)
+            results[node_id] = result
+            context[node_id] = result
+        return results
+
+    def _topological_sort(self, workflow: Workflow) -> List[str]:
+        graph: Dict[str, List[str]] = {nid: [] for nid in workflow.nodes}
+        indegree: Dict[str, int] = {nid: 0 for nid in workflow.nodes}
+        for c in workflow.connections:
+            if c.type == ConnectionType.SUCCESS:
+                graph[c.source_id].append(c.target_id)
+                indegree[c.target_id] += 1
+        queue = [n for n, d in indegree.items() if d == 0]
+        order: List[str] = []
+        while queue:
+            current = queue.pop(0)
+            order.append(current)
+            for neigh in graph[current]:
+                indegree[neigh] -= 1
+                if indegree[neigh] == 0:
+                    queue.append(neigh)
+        if len(order) != len(workflow.nodes):
+            raise ValueError("Workflow contains cycles")
+        return order


### PR DESCRIPTION
## Summary
- implement new lightweight `workflow_engine` package with core classes
- expose workflow routes in `back/api/workflows.py`
- register new router in FastAPI app
- add unit tests for workflow engine

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6885356a6e9c8325b20e8a24e1a4574a