### PR TITLE
Add JWT auth verification for /auth/me endpoint

### DIFF
--- a/back/agenthub/auth/routes.py
+++ b/back/agenthub/auth/routes.py
@@ -5,13 +5,14 @@ from agenthub.auth.schemas import SignInInput
 from agenthub.auth.utils import verify_password
 from agenthub.database.connection import get_db
 from agenthub.models.user import User
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status, Header
+from jose import jwt, JWTError
 from passlib.context import CryptContext
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from .schemas import UserCreate
-from .utils import create_access_token, verify_password
+from .utils import create_access_token, verify_password, SECRET_KEY, ALGORITHM
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -97,7 +98,27 @@ def login(user: SignInInput, db: Session = Depends(get_db)):
     }
 
 @router.get("/me")
-def get_current_user(db: Session = Depends(get_db)):
-    """Obtener información del usuario actual - placeholder"""
-    # TODO: Implementar verificación de token JWT
-    return {"message": "Endpoint de usuario actual - por implementar"}
+def get_current_user(
+    db: Session = Depends(get_db),
+    authorization: str | None = Header(default=None)
+):
+    """Return the currently authenticated user."""
+
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+
+    token = authorization.split(" ", 1)[1]
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+    except JWTError:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+
+    user_id = payload.get("user_id")
+    if user_id is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+
+    return {"id": user.id, "email": user.email, "is_active": user.is_active}

--- a/back/tests/integration/test_auth_routes.py
+++ b/back/tests/integration/test_auth_routes.py
@@ -1,0 +1,49 @@
+import os
+from passlib.context import CryptContext
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///./test.db")
+
+from agenthub.main import app
+from agenthub.database.connection import Base, engine, SessionLocal
+from agenthub.models.user import User
+from agenthub.auth.utils import create_access_token
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def setup_module(module):
+    Base.metadata.create_all(bind=engine)
+
+def teardown_module(module):
+    Base.metadata.drop_all(bind=engine)
+
+
+def create_user(email: str, password: str) -> User:
+    db = SessionLocal()
+    user = User(email=email, hashed_password=pwd_context.hash(password))
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    db.close()
+    return user
+
+
+client = TestClient(app)
+
+
+def test_get_current_user_with_valid_token():
+    user = create_user("valid@example.com", "secret")
+    token = create_access_token({"sub": user.email, "user_id": user.id})
+    resp = client.get("/auth/me", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == user.id
+    assert data["email"] == user.email
+    assert data["is_active"] == user.is_active
+
+
+def test_get_current_user_invalid_token():
+    resp = client.get("/auth/me", headers={"Authorization": "Bearer badtoken"})
+    assert resp.status_code == 401
+


### PR DESCRIPTION
## Summary
- implement JWT validation in `get_current_user`
- add integration tests for the `/auth/me` route

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for several dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6885356dcb588325b40e19df864cd51f