### PR TITLE
Update workflow client and websocket config

### DIFF
--- a/front/src/config/api.js
+++ b/front/src/config/api.js
@@ -12,6 +12,7 @@ export const ENDPOINTS = {
   AGENTS_REGISTER: '/agents/register',
   MESSAGE_SEND: '/message/send',
   WORKFLOWS: '/workflows',
+  WORKFLOWS_REGISTER: '/workflows/register',
   WORKFLOW_START: '/workflow/start',
   AUTH_LOGIN: '/auth/signin',
   AUTH_SIGNUP: '/auth/signup',

--- a/front/src/config/enterprise.js
+++ b/front/src/config/enterprise.js
@@ -12,7 +12,11 @@ const config = {
 
   api: {
     baseURL: process.env.REACT_APP_API_URL || 'http://localhost:8000',
-    wsURL: process.env.REACT_APP_WS_URL || 'ws://localhost:8000/ws',
+    wsURL:
+      process.env.REACT_APP_WS_URL ||
+      (process.env.REACT_APP_API_URL
+        ? process.env.REACT_APP_API_URL.replace(/^http/, 'ws') + '/ws'
+        : 'ws://localhost:8000/ws'),
     timeout: parseInt(process.env.REACT_APP_API_TIMEOUT) || 30000,
     maxRetries: parseInt(process.env.REACT_APP_MAX_RETRIES) || 3
   },

--- a/front/src/services/iopeerAPI.js
+++ b/front/src/services/iopeerAPI.js
@@ -76,7 +76,14 @@ class IopeerAPI {
     return this.request('/workflows');
   }
 
-  async startWorkflow(workflowName, data = {}) {
+  async createWorkflow({ name, tasks = [], parallel = false, timeout = 30 }) {
+    return this.request('/workflows/register', {
+      method: 'POST',
+      body: JSON.stringify({ name, tasks, parallel, timeout }),
+    });
+  }
+
+  async executeWorkflow(workflowName, data = {}) {
     return this.request('/workflow/start', {
       method: 'POST',
       body: JSON.stringify({


### PR DESCRIPTION
## Summary
- add `WORKFLOWS_REGISTER` endpoint constant
- compute WebSocket URL from the API base URL when not provided
- extend `IopeerAPI` with `createWorkflow` and `executeWorkflow`

## Testing
- `make test` *(fails: unrecognized arguments --cov=agenthub)*

------
https://chatgpt.com/codex/tasks/task_e_688535830a508325ab44848a54bf2b66