### PR TITLE
Fix token retrieval in IopeerAPI

### DIFF
--- a/front/src/services/iopeerAPI.js
+++ b/front/src/services/iopeerAPI.js
@@ -16,13 +16,19 @@ class IopeerAPI {
 
     const timeoutId = setTimeout(() => controller.abort(), this.timeout);
 
+    const token = localStorage.getItem('token');
+    const headers = {
+      'Content-Type': 'application/json',
+      'X-Requested-With': 'XMLHttpRequest',
+      ...options.headers,
+    };
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+    }
+
     try {
       const response = await fetch(url, {
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Requested-With': 'XMLHttpRequest',
-          ...options.headers,
-        },
+        headers,
         signal: controller.signal,
         ...options,
       });


### PR DESCRIPTION
## Summary
- refresh Authorization header on each request

## Testing
- `make test` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_6885358d7b008325a3d9ce32a5939583