### PR TITLE
Fix duplicate imports in auth routes

### DIFF
--- a/back/agenthub/auth/routes.py
+++ b/back/agenthub/auth/routes.py
@@ -1,8 +1,6 @@
 import logging
 
-from agenthub.auth.auth import create_access_token
 from agenthub.auth.schemas import SignInInput
-from agenthub.auth.utils import verify_password
 from agenthub.database.connection import get_db
 from agenthub.models.user import User
 from fastapi import APIRouter, Depends, HTTPException, status


### PR DESCRIPTION
## Summary
- remove duplicated create_access_token and verify_password imports

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `flake8 back/agenthub` *(fails: command not found)*
- `mypy back/agenthub` *(fails: missing stubs for fastapi, sqlalchemy, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688535abf3bc8325a0967160ff586eed