### PR TITLE
Add message_sent flag to send_message response

### DIFF
--- a/back/agenthub/main.py
+++ b/back/agenthub/main.py
@@ -323,7 +323,7 @@ async def send_message(req: MessageRequest):
         )
         
         logger.info(f"📨 Response from {req.agent_id}: {result}")
-        return {"result": result, "status": "success"}
+        return {"message_sent": True, "result": result, "status": "success"}
 
     except ValueError as e:
         logger.error(f"Agent not found: {e}")

--- a/back/main.py
+++ b/back/main.py
@@ -322,7 +322,7 @@ async def send_message(req: MessageRequest):
         )
         
         logger.info(f"📨 Response from {req.agent_id}: {result}")
-        return {"result": result, "status": "success"}
+        return {"message_sent": True, "result": result, "status": "success"}
 
     except ValueError as e:
         logger.error(f"Agent not found: {e}")


### PR DESCRIPTION
## Summary
- include `message_sent` flag in `send_message` endpoint

## Testing
- `pytest -q back/tests/integration/test_api.py::TestAPI::test_send_message -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_688535aee8bc832598a3ce661c8826bb