### PR TITLE
Clarify unsupported auth features

### DIFF
--- a/front/src/i18n/en.json
+++ b/front/src/i18n/en.json
@@ -23,13 +23,13 @@
     "email": "Email",
     "password": "Password",
     "remember": "Remember me",
-    "forgot": "Forgot your password?",
+    "forgot": "Forgot your password? (not supported yet)",
     "submit": "Sign In",
     "continue": "Or continue with",
     "google": "Google",
     "github": "GitHub",
     "noAccount": "Don't have an account?",
-    "register": "Register here"
+    "register": "Registration coming soon"
   },
   "hero": {
     "titlePart1": "Revolutionize your",

--- a/front/src/i18n/es.json
+++ b/front/src/i18n/es.json
@@ -23,13 +23,13 @@
     "email": "Email",
     "password": "Contraseña",
     "remember": "Recordarme",
-    "forgot": "¿Olvidaste tu contraseña?",
+    "forgot": "¿Olvidaste tu contraseña? (no disponible)",
     "submit": "Iniciar Sesión",
     "continue": "O continúa con",
     "google": "Google",
     "github": "GitHub",
     "noAccount": "¿No tienes cuenta?",
-    "register": "Regístrate aquí"
+    "register": "Registro próximamente"
   },
   "hero": {
     "titlePart1": "Revoluciona tu",

--- a/front/src/pages/Login.jsx
+++ b/front/src/pages/Login.jsx
@@ -67,8 +67,7 @@ const Login = () => {
 
   const handleSignUp = (e) => {
     e.preventDefault();
-    // TODO: Implementar registro
-    navigate('/signup'); // Redirect to signup page when implemented
+    alert('Registro no disponible aún');
   };
 
   return (


### PR DESCRIPTION
## Summary
- update translations to indicate password recovery and sign up are not yet available
- disable sign up navigation and show alert

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `bash back/scripts/test.sh` *(fails: could not install flake8)*

------
https://chatgpt.com/codex/tasks/task_e_688535b334a48325b675df9ce65e97ac