### PR TITLE
Add orchestrator shutdown

### DIFF
--- a/back/agenthub/main.py
+++ b/back/agenthub/main.py
@@ -90,6 +90,7 @@ async def startup_event():
 
 async def shutdown_event():
     """Cleanup on shutdown"""
+    orchestrator.shutdown()
     logger.info("✅ Shutdown complete")
 
 def test_db_connection():

--- a/back/agenthub/orchestrator.py
+++ b/back/agenthub/orchestrator.py
@@ -313,6 +313,10 @@ class Orchestrator:
             or 0,
         }
 
+    def shutdown(self) -> None:
+        """Detiene el ejecutor de hilos"""
+        self.executor.shutdown(wait=False)
+
 
 # Instancia global
 orchestrator = Orchestrator()


### PR DESCRIPTION
## Summary
- implement `shutdown()` in `orchestrator.py`
- call `orchestrator.shutdown()` during app shutdown

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for dotenv, yaml, requests)*

------
https://chatgpt.com/codex/tasks/task_e_688535d8dd0c83258c01d5f4333eb35b