### PR TITLE
Remove redundant default workflow registration

### DIFF
--- a/back/agenthub/workflows/default.py
+++ b/back/agenthub/workflows/default.py
@@ -55,7 +55,3 @@ def register_default_workflows():
         ],
         parallel=True,
     )
-
-
-# Auto-registrar al importar
-register_default_workflows()


### PR DESCRIPTION
## Summary
- remove automatic call to `register_default_workflows` so workflows are only
  registered from `startup_event`

## Testing
- `make format`
- `make lint` *(fails: flake8 not installed)*
- `make test` *(fails: pytest option --cov not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_688535db172c83259e2c8b4ca8cc3e9f