### PR TITLE
Add workflow demo module with landing integration

### DIFF
--- a/front/src/demos/workflowDemo.js
+++ b/front/src/demos/workflowDemo.js
@@ -1,0 +1,98 @@
+// front/src/demos/workflowDemo.js
+// Simple workflow demo runner and UI manager
+import { iopeerAPI } from '../services/iopeerAPI';
+
+// Demo step constants
+export const DEMO_STARTUP_COMPLETE = 'startup_complete';
+export const DEMO_AGENTS_LOADED = 'agents_loaded';
+export const DEMO_WORKFLOW_FINISHED = 'workflow_finished';
+
+// Basic UI manager that shows demo status on screen
+export class DemoUIManager {
+  constructor() {
+    this.container = null;
+    this.steps = {};
+  }
+
+  init() {
+    if (this.container) return;
+    this.container = document.createElement('div');
+    this.container.id = 'workflow-demo';
+    this.container.className = 'fixed inset-0 z-50 flex items-center justify-center bg-black/60';
+
+    const box = document.createElement('div');
+    box.className = 'bg-white rounded-lg shadow-xl p-6 space-y-4 max-w-sm text-center';
+    this.list = document.createElement('ul');
+    box.appendChild(this.list);
+    this.container.appendChild(box);
+    document.body.appendChild(this.container);
+  }
+
+  update(step, message) {
+    if (!this.container) this.init();
+    let item = this.steps[step];
+    if (!item) {
+      item = document.createElement('li');
+      item.className = 'text-gray-700 flex items-center gap-2';
+      item.textContent = message;
+      this.list.appendChild(item);
+      this.steps[step] = item;
+    } else {
+      item.textContent = message;
+    }
+  }
+
+  error(message) {
+    this.update('error', `❌ ${message}`);
+  }
+
+  complete() {
+    this.update(DEMO_WORKFLOW_FINISHED, '✅ Demo completada');
+    setTimeout(() => {
+      if (this.container) {
+        document.body.removeChild(this.container);
+        this.container = null;
+      }
+    }, 2000);
+  }
+}
+
+// Runner that performs simple workflow calls
+export class WorkflowDemoRunner {
+  constructor(api = iopeerAPI, uiManager = new DemoUIManager(), workflow = 'api_development') {
+    this.api = api;
+    this.ui = uiManager;
+    this.workflow = workflow;
+  }
+
+  async start() {
+    this.ui.init();
+    try {
+      this.ui.update(DEMO_STARTUP_COMPLETE, '⏳ Verificando backend...');
+      await this.api.getHealth();
+      this.ui.update(DEMO_STARTUP_COMPLETE, '✅ Backend conectado');
+
+      this.ui.update(DEMO_AGENTS_LOADED, '⏳ Cargando agentes...');
+      const agents = await this.api.getAgents();
+      this.ui.update(DEMO_AGENTS_LOADED, `✅ ${agents.agents?.length || 0} agentes listos`);
+
+      this.ui.update('workflow', '⏳ Ejecutando workflow de ejemplo...');
+      await this.api.startWorkflow(this.workflow, { demo: true });
+      this.ui.update('workflow', '✅ Workflow finalizado');
+
+      this.ui.complete();
+    } catch (err) {
+      console.error('Demo error:', err);
+      this.ui.error(err.message);
+    }
+  }
+}
+
+// Helper to start demo easily
+export const startWorkflowDemo = () => {
+  const runner = new WorkflowDemoRunner();
+  runner.start();
+  return runner;
+};
+
+export default startWorkflowDemo;

--- a/front/src/hooks/useLanding.js
+++ b/front/src/hooks/useLanding.js
@@ -3,6 +3,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { marketplaceService } from '../services/marketplace.service';
 import { useAuth } from '../context/AuthContext';
 import { useNavigate } from 'react-router-dom';
+import { startWorkflowDemo } from '../demos/workflowDemo';
 
 export const useLanding = () => {
   const [featuredAgents, setFeaturedAgents] = useState([]);
@@ -82,9 +83,7 @@ export const useLanding = () => {
 
   // Manejar botón "Ver Demo"
   const handleWatchDemo = useCallback(() => {
-    // Aquí podrías abrir un modal con video o navegar a una página de demo
-    console.log('Showing demo...');
-    // navigate('/demo');
+    startWorkflowDemo();
   }, []);
 
   // Manejar "Explorar Marketplace"


### PR DESCRIPTION
## Summary
- implement demo runner and UI manager under `front/src/demos`
- integrate demo trigger from the landing page hooks

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npx eslint src/demos/workflowDemo.js` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_688535e67d9483258661bc8f50bb1ab2