### PR TITLE
Implement signup and password reset

### DIFF
--- a/front/src/App.js
+++ b/front/src/App.js
@@ -6,6 +6,8 @@ import ErrorBoundary from './components/ui/ErrorBoundary';
 import Login from './pages/Login';
 import LandingPage from './pages/LandingPage';
 import OAuthCallback from './pages/OAuthCallback';
+import SignUp from './pages/SignUp';
+import ForgotPassword from './pages/ForgotPassword';
 import { AuthProvider, useAuth } from './context/AuthContext';
 import Dashboard from './pages/Dashboard';
 
@@ -78,13 +80,29 @@ function AppContent() {
             </PublicRoute>
           } 
         />
-        <Route 
-          path="/login" 
+        <Route
+          path="/login"
           element={
             <PublicRoute>
               <Login />
             </PublicRoute>
-          } 
+          }
+        />
+        <Route
+          path="/signup"
+          element={
+            <PublicRoute>
+              <SignUp />
+            </PublicRoute>
+          }
+        />
+        <Route
+          path="/forgot-password"
+          element={
+            <PublicRoute>
+              <ForgotPassword />
+            </PublicRoute>
+          }
         />
         
         {/* OAuth Callback Route - DEBE SER PÚBLICO */}

--- a/front/src/api/auth.js
+++ b/front/src/api/auth.js
@@ -23,3 +23,14 @@ export async function signupRequest(email, password) {
   });
   return res.json();
 }
+
+export async function passwordResetRequest(email) {
+  const res = await fetch(`${API_URL}/reset-password`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ email }),
+  });
+  return res.json();
+}

--- a/front/src/api/auth.test.js
+++ b/front/src/api/auth.test.js
@@ -1,0 +1,30 @@
+import { signupRequest, passwordResetRequest } from './auth';
+
+global.fetch = jest.fn(() =>
+  Promise.resolve({
+    json: () => Promise.resolve({ message: 'ok' })
+  })
+);
+
+describe('auth api', () => {
+  beforeEach(() => {
+    fetch.mockClear();
+    process.env.REACT_APP_API_URL = 'http://localhost:8000';
+  });
+
+  test('signupRequest posts to /signup', async () => {
+    await signupRequest('a@b.com', 'x');
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost:8000/auth/signup',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  test('passwordResetRequest posts to /reset-password', async () => {
+    await passwordResetRequest('a@b.com');
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost:8000/auth/reset-password',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+});

--- a/front/src/i18n/en.json
+++ b/front/src/i18n/en.json
@@ -31,6 +31,17 @@
     "noAccount": "Don't have an account?",
     "register": "Register here"
   },
+  "signup": {
+    "title": "Create an account",
+    "submit": "Sign Up",
+    "haveAccount": "Already have an account?",
+    "login": "Log in"
+  },
+  "reset": {
+    "title": "Reset your password",
+    "submit": "Send reset link",
+    "success": "If that email exists, you'll receive reset instructions."
+  },
   "hero": {
     "titlePart1": "Revolutionize your",
     "titleHighlight": "Development",

--- a/front/src/i18n/es.json
+++ b/front/src/i18n/es.json
@@ -31,6 +31,17 @@
     "noAccount": "¿No tienes cuenta?",
     "register": "Regístrate aquí"
   },
+  "signup": {
+    "title": "Crea una cuenta",
+    "submit": "Registrarse",
+    "haveAccount": "¿Ya tienes cuenta?",
+    "login": "Inicia sesión"
+  },
+  "reset": {
+    "title": "Restablecer contraseña",
+    "submit": "Enviar enlace",
+    "success": "Si el correo existe, recibirás instrucciones."
+  },
   "hero": {
     "titlePart1": "Revoluciona tu",
     "titleHighlight": "Desarrollo",

--- a/front/src/pages/ForgotPassword.jsx
+++ b/front/src/pages/ForgotPassword.jsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { passwordResetService } from '../services/auth.service';
+
+const ForgotPassword = () => {
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('');
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setMessage('');
+    const res = await passwordResetService(email);
+    if (res.success) {
+      setMessage(t('reset.success'));
+    } else {
+      setMessage(res.error);
+    }
+  };
+
+  const goToLogin = (e) => {
+    e.preventDefault();
+    navigate('/login');
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
+      <div className="sm:mx-auto sm:w-full sm:max-w-md">
+        <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
+          {t('reset.title')}
+        </h2>
+      </div>
+      <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+        <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
+          {message && (
+            <div className="mb-4 bg-green-50 border border-green-200 text-green-700 px-4 py-3 rounded">
+              {message}
+            </div>
+          )}
+          <form className="space-y-6" onSubmit={handleSubmit}>
+            <div>
+              <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+                Email
+              </label>
+              <div className="mt-1">
+                <input
+                  id="email"
+                  name="email"
+                  type="email"
+                  required
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md placeholder-gray-400 focus:outline-none focus:ring-green-500 focus:border-green-500 sm:text-sm"
+                />
+              </div>
+            </div>
+            <div>
+              <button
+                type="submit"
+                className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
+              >
+                {t('reset.submit')}
+              </button>
+            </div>
+          </form>
+          <div className="mt-6 text-center">
+            <button type="button" onClick={goToLogin} className="font-medium text-green-600 hover:text-green-500">
+              {t('signup.login')}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ForgotPassword;

--- a/front/src/pages/Login.jsx
+++ b/front/src/pages/Login.jsx
@@ -61,14 +61,12 @@ const Login = () => {
 
   const handleForgotPassword = (e) => {
     e.preventDefault();
-    // TODO: Implementar recuperación de contraseña
-    alert('Funcionalidad de recuperación de contraseña pendiente');
+    navigate('/forgot-password');
   };
 
   const handleSignUp = (e) => {
     e.preventDefault();
-    // TODO: Implementar registro
-    navigate('/signup'); // Redirect to signup page when implemented
+    navigate('/signup');
   };
 
   return (

--- a/front/src/pages/SignUp.jsx
+++ b/front/src/pages/SignUp.jsx
@@ -1,0 +1,105 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { signupService } from '../services/auth.service';
+
+const SignUp = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setIsLoading(true);
+    setError('');
+    const res = await signupService(email, password);
+    if (res.success) {
+      navigate('/login');
+    } else {
+      setError(res.error);
+    }
+    setIsLoading(false);
+  };
+
+  const goToLogin = (e) => {
+    e.preventDefault();
+    navigate('/login');
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
+      <div className="sm:mx-auto sm:w-full sm:max-w-md">
+        <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
+          {t('signup.title')}
+        </h2>
+      </div>
+      <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+        <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
+          {error && (
+            <div className="mb-4 bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded">
+              {error}
+            </div>
+          )}
+          <form className="space-y-6" onSubmit={handleSubmit}>
+            <div>
+              <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+                Email
+              </label>
+              <div className="mt-1">
+                <input
+                  id="email"
+                  name="email"
+                  type="email"
+                  autoComplete="email"
+                  required
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md placeholder-gray-400 focus:outline-none focus:ring-green-500 focus:border-green-500 sm:text-sm"
+                />
+              </div>
+            </div>
+            <div>
+              <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+                {t('login.password')}
+              </label>
+              <div className="mt-1">
+                <input
+                  id="password"
+                  name="password"
+                  type="password"
+                  autoComplete="new-password"
+                  required
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md placeholder-gray-400 focus:outline-none focus:ring-green-500 focus:border-green-500 sm:text-sm"
+                />
+              </div>
+            </div>
+            <div>
+              <button
+                type="submit"
+                disabled={isLoading}
+                className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {t('signup.submit')}
+              </button>
+            </div>
+          </form>
+          <div className="mt-6 text-center">
+            <p className="text-sm text-gray-600">
+              {t('signup.haveAccount')}{' '}
+              <button type="button" onClick={goToLogin} className="font-medium text-green-600 hover:text-green-500">
+                {t('signup.login')}
+              </button>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SignUp;

--- a/front/src/services/auth.service.js
+++ b/front/src/services/auth.service.js
@@ -1,4 +1,4 @@
-import { loginRequest } from "../api/auth";
+import { loginRequest, signupRequest, passwordResetRequest } from "../api/auth";
 
 export async function loginService(email, password) {
   try {
@@ -10,6 +10,32 @@ export async function loginService(email, password) {
     }
 
     return { success: false, error: data.detail || "Credenciales inválidas" };
+  } catch (err) {
+    return { success: false, error: "Error de servidor" };
+  }
+}
+
+export async function signupService(email, password) {
+  try {
+    const data = await signupRequest(email, password);
+
+    if (data.message) {
+      return { success: true };
+    }
+
+    return { success: false, error: data.detail || "Error" };
+  } catch (err) {
+    return { success: false, error: "Error de servidor" };
+  }
+}
+
+export async function passwordResetService(email) {
+  try {
+    const data = await passwordResetRequest(email);
+    if (data.message) {
+      return { success: true };
+    }
+    return { success: false, error: data.detail || "Error" };
   } catch (err) {
     return { success: false, error: "Error de servidor" };
   }


### PR DESCRIPTION
## Summary
- add passwordResetRequest API call
- expand auth service with signup and password reset helpers
- implement signup and forgot password pages
- wire new pages into router
- link actions from Login page
- add i18n text for new pages
- add unit tests for auth API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688535e86ad88325bf893a42c7ceaf6e