### PR TITLE
Fix workflow API duplicates

### DIFF
--- a/front/src/services/iopeerAPI.js
+++ b/front/src/services/iopeerAPI.js
@@ -99,16 +99,9 @@ class IopeerAPI {
     });
   }
 
-  async createWorkflow({ name, tasks = [], parallel = false, timeout }) {
-    return this.request('/workflows/register', {
-      method: 'POST',
-      body: JSON.stringify({
-        name,
-        tasks,
-        parallel,
-        timeout,
-      }),
-    });
+  // Alias kept for backwards compatibility
+  async startWorkflow(workflowName, data = {}) {
+    return this.executeWorkflow(workflowName, data);
   }
 
   // Stats


### PR DESCRIPTION
## Summary
- remove duplicate `createWorkflow`
- add `startWorkflow` alias for running workflows

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_688541f82eec8325bf16d9c993fdb568