### PR TITLE
Fix effect dependencies in frontend

### DIFF
--- a/front/src/components/debug/IntegrationTest.jsx
+++ b/front/src/components/debug/IntegrationTest.jsx
@@ -140,7 +140,7 @@ const IntegrationTest = () => {
     if (isLoggedIn && isConnected) {
       setTimeout(runAllTests, 1000);
     }
-  }, [isLoggedIn, isConnected]);
+  }, [isLoggedIn, isConnected, runAllTests]);
 
   // Función para login de prueba
   const testLogin = async () => {

--- a/front/src/components/features/UIGenerator/UIGenerator.jsx
+++ b/front/src/components/features/UIGenerator/UIGenerator.jsx
@@ -70,12 +70,12 @@ const UIGenerator = () => {
   // Cargar componentes soportados al inicializar
   useEffect(() => {
     loadSupportedComponents();
-  }, []);
+  }, [loadSupportedComponents]);
 
   // Actualizar props cuando cambia el componente seleccionado
   useEffect(() => {
     setComponentProps(defaultProps[selectedComponent] || {});
-  }, [selectedComponent]);
+  }, [selectedComponent, defaultProps]);
 
   const loadSupportedComponents = async () => {
     try {

--- a/front/src/hooks/useIopeer.js
+++ b/front/src/hooks/useIopeer.js
@@ -137,7 +137,7 @@ export const useIopeer = () => {
     } finally {
       setLoading(false);
     }
-  }, [makeRequest, handleError, retryAttempts, maxRetries, agents]);
+  }, [makeRequest, handleError, retryAttempts, maxRetries, agents, clearError]);
 
   const sendMessage = useCallback(async (agentId, action, data = {}) => {
     if (connectionStatus !== 'connected') {


### PR DESCRIPTION
## Summary
- add `clearError` to `connect` callback dependencies
- watch `loadSupportedComponents` and `defaultProps` in `UIGenerator` effects
- depend on `runAllTests` in `IntegrationTest`

## Testing
- `npm start --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688541f8941c8325a9221528f800364c