### PR TITLE
Fix missing imports in auth utils

### DIFF
--- a/back/agenthub/auth/utils.py
+++ b/back/agenthub/auth/utils.py
@@ -2,6 +2,8 @@
 from datetime import datetime, timedelta
 
 from fastapi import HTTPException, status
+from passlib.context import CryptContext
+from jose import jwt, JWTError
 
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")


### PR DESCRIPTION
## Summary
- import CryptContext from passlib
- import jwt and JWTError from jose

## Testing
- `make lint` *(fails: flake8 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688541fbd87c83258bc41db487c6ead1