### PR TITLE
Fix workflows import

### DIFF
--- a/back/api/workflows.py
+++ b/back/api/workflows.py
@@ -4,8 +4,8 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 
-from ..workflow_engine import runtime
-from ..workflow_engine.core.WorkflowEngine import (
+from workflow_engine import runtime
+from workflow_engine.core.WorkflowEngine import (
     Workflow,
     WorkflowNode,
     WorkflowConnection,


### PR DESCRIPTION
## Summary
- switch to absolute workflow_engine imports

## Testing
- `make run` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_688562ffae948325ba783f0a0aea2edf