### PR TITLE
Fix missing HTTPBearer import

### DIFF
--- a/back/agenthub/auth/routes.py
+++ b/back/agenthub/auth/routes.py
@@ -7,6 +7,7 @@ from agenthub.database.connection import get_db
 from agenthub.models.user import User
 
 from fastapi import APIRouter, Depends, HTTPException, status, Request
+from fastapi.security import HTTPBearer
 
 from passlib.context import CryptContext
 from pydantic import BaseModel


### PR DESCRIPTION
## Summary
- add missing HTTPBearer import in auth routes

## Testing
- `make test` *(fails: unrecognized arguments --cov=agenthub)*

------
https://chatgpt.com/codex/tasks/task_e_68856520014883258f97283c4c569979