### PR TITLE
Add new agent setup utilities

### DIFF
--- a/back/agenthub/agents/__init__.py
+++ b/back/agenthub/agents/__init__.py
@@ -1,0 +1,11 @@
+from .backend_agent import BackendAgent
+from .qa_agent import QAAgent
+from .ui_generator_agent import UIGeneratorAgent
+from .data_analyst_agent import DataAnalystAgent
+
+__all__ = [
+    "BackendAgent",
+    "QAAgent",
+    "UIGeneratorAgent",
+    "DataAnalystAgent",
+]

--- a/back/agenthub/agents/ui_generator_agent.py
+++ b/back/agenthub/agents/ui_generator_agent.py
@@ -1,0 +1,10 @@
+from .ui_component_generator import UIComponentGeneratorAgent
+
+
+class UIGeneratorAgent(UIComponentGeneratorAgent):
+    """Alias of UIComponentGeneratorAgent with simplified agent ID."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.agent_id = "ui_generator"
+        self.name = "UI Generator"

--- a/back/main.py
+++ b/back/main.py
@@ -83,6 +83,9 @@ async def startup_event():
         # 3. Load agents from registry
         await load_agents_from_registry()
 
+        # 3b. Load built-in agents
+        load_agents()
+
         # 4. Load default workflows
         try:
             from agenthub.workflows.default import register_default_workflows
@@ -167,6 +170,39 @@ async def load_agents_from_registry():
             logger.error(f"❌ Failed to load agent {agent_id}: {e}")
 
     logger.info(f"✅ {agents_loaded} agents loaded successfully")
+
+
+def load_agents():
+    """Load all available agents"""
+    registry = orchestrator.agent_registry
+
+    # Load existing agents
+    from agenthub.agents.backend_agent import BackendAgent
+    from agenthub.agents.qa_agent import QAAgent
+
+    registry.register_agent(BackendAgent())
+    registry.register_agent(QAAgent())
+
+    # Load NEW agents
+    try:
+        from agenthub.agents.ui_generator_agent import UIGeneratorAgent
+        registry.register_agent(UIGeneratorAgent())
+        logger.info("✅ Loaded agent: ui_generator")
+    except ImportError as e:
+        logger.error(f"❌ Failed to load ui_generator: {e}")
+
+    try:
+        from agenthub.agents.data_analyst_agent import DataAnalystAgent
+        registry.register_agent(DataAnalystAgent())
+        logger.info("✅ Loaded agent: data_analyst")
+    except ImportError as e:
+        logger.error(f"❌ Failed to load data_analyst: {e}")
+
+    logger.info(f"✅ {len(registry.agents)} agents loaded successfully")
+
+    # Log all loaded agents
+    for agent_id in registry.agents.keys():
+        logger.info(f"✅ Loaded agent: {agent_id}")
 
 
 async def create_default_registry(path: Path):

--- a/scripts/quick_test.py
+++ b/scripts/quick_test.py
@@ -1,0 +1,50 @@
+import requests
+import json
+
+
+def test_api():
+    """Quick API test after setup"""
+    base_url = "http://localhost:8000"
+
+    tests = [
+        ("Root endpoint", "GET", "/"),
+        ("Health check", "GET", "/health"),
+        ("Agents list", "GET", "/agents"),
+        ("Frontend config", "GET", "/frontend/config"),
+        ("UI Generator details", "GET", "/agents/ui_generator"),
+        ("Workflows list", "GET", "/workflows"),
+    ]
+
+    print("\N{test tube} Running quick API tests...\n")
+
+    for test_name, method, endpoint in tests:
+        try:
+            response = requests.get(f"{base_url}{endpoint}", timeout=5)
+
+            if response.status_code == 200:
+                print(f"\N{check mark} {test_name}: OK")
+
+                # Show key data for some endpoints
+                if endpoint == "/":
+                    data = response.json()
+                    print(
+                        f"   \N{bar chart} Agents: {data.get('agents')}, Workflows: {data.get('workflows')}"
+                    )
+                elif endpoint == "/agents":
+                    data = response.json()
+                    agents = [agent['agent_id'] for agent in data.get('agents', [])]
+                    print(f"   \N{robot} Loaded agents: {agents}")
+
+            else:
+                print(f"\N{cross mark} {test_name}: HTTP {response.status_code}")
+
+        except requests.exceptions.ConnectionError:
+            print(f"\N{electric plug} {test_name}: Server not running")
+        except Exception as e:
+            print(f"\N{cross mark} {test_name}: {str(e)}")
+
+    print("\n\N{test tube} Quick tests complete!")
+
+
+if __name__ == "__main__":
+    test_api()

--- a/scripts/reset_auth.py
+++ b/scripts/reset_auth.py
@@ -1,0 +1,41 @@
+import asyncio
+import sys
+import os
+
+# Add parent directory to path to import database
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+async def reset_auth_data():
+    """Reset auth data for clean testing"""
+    try:
+        # Import database connection
+        from database import database
+
+        await database.connect()
+        print("\N{electric plug} Connected to database")
+
+        # Delete test user if exists
+        result = await database.execute(
+            "DELETE FROM users WHERE email = ?",
+            ("test@iopeer.com",),
+        )
+        print(f"\N{wastebasket} Deleted {result} test users")
+
+        # Optional: Clear all users (uncomment if needed)
+        # await database.execute("DELETE FROM users")
+        # print("\N{wastebasket} Deleted all users")
+
+        print("\N{check mark} Auth data reset complete")
+
+    except Exception as e:
+        print(f"\N{cross mark} Error resetting auth data: {e}")
+
+    finally:
+        await database.disconnect()
+        print("\N{electric plug} Disconnected from database")
+
+
+if __name__ == "__main__":
+    print("\N{broom} Resetting auth data...")
+    asyncio.run(reset_auth_data())

--- a/scripts/test_ui_generator.py
+++ b/scripts/test_ui_generator.py
@@ -1,0 +1,80 @@
+import requests
+import json
+
+
+def test_ui_generator():
+    """Test UI Generator specifically"""
+    base_url = "http://localhost:8000"
+
+    print("\N{artist palette} Testing UI Generator...\n")
+
+    # Test 1: Check if agent exists
+    try:
+        response = requests.get(f"{base_url}/agents/ui_generator")
+        if response.status_code == 200:
+            print("\N{check mark} UI Generator agent found")
+            data = response.json()
+            print(
+                f"   \N{clipboard} Actions: {data.get('capabilities', {}).get('actions', [])}"
+            )
+        else:
+            print(f"\N{cross mark} UI Generator agent not found: HTTP {response.status_code}")
+            return
+    except Exception as e:
+        print(f"\N{cross mark} Failed to check UI Generator: {e}")
+        return
+
+    # Test 2: Generate a button
+    test_cases = [
+        {
+            "name": "Basic Button",
+            "data": {
+                "agent_id": "ui_generator",
+                "action": "generate_component",
+                "data": {
+                    "type": "button",
+                    "props": {"name": "TestButton", "text": "Click Me", "variant": "primary"},
+                },
+            },
+        },
+        {
+            "name": "Card Component",
+            "data": {
+                "agent_id": "ui_generator",
+                "action": "generate_component",
+                "data": {
+                    "type": "card",
+                    "props": {"name": "TestCard", "title": "Sample Card", "shadow": "large"},
+                },
+            },
+        },
+    ]
+
+    for test_case in test_cases:
+        try:
+            response = requests.post(
+                f"{base_url}/message/send",
+                json=test_case["data"],
+                headers={"Content-Type": "application/json"},
+            )
+
+            if response.status_code == 200:
+                result = response.json()
+                if result.get("status") == "success":
+                    print(f"\N{check mark} {test_case['name']}: Generated successfully")
+                    data = result.get("data", {})
+                    print(f"   \N{page facing up} File: {data.get('filename')}")
+                    print(f"   \N{straight ruler} Lines: {data.get('estimated_lines', 'N/A')}")
+                else:
+                    print(f"\N{cross mark} {test_case['name']}: {result.get('error')}")
+            else:
+                print(f"\N{cross mark} {test_case['name']}: HTTP {response.status_code}")
+
+        except Exception as e:
+            print(f"\N{cross mark} {test_case['name']}: {str(e)}")
+
+    print("\n\N{artist palette} UI Generator tests complete!")
+
+
+if __name__ == "__main__":
+    test_ui_generator()

--- a/scripts/verify_setup.py
+++ b/scripts/verify_setup.py
@@ -1,0 +1,54 @@
+import asyncio
+import sys
+import os
+import json
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+async def verify_setup():
+    """Verify that all components are working"""
+    print("\N{left magnifying glass} Verifying IOPeer setup...")
+
+    try:
+        # Test 1: Import orchestrator
+        from agenthub.orchestrator import AgentOrchestrator
+        orchestrator = AgentOrchestrator()
+        print("\N{check mark} Orchestrator imported successfully")
+
+        # Test 2: Load agents
+        from main import load_agents
+        print("\N{check mark} Load agents function imported")
+
+        # Test 3: Import all agents individually
+        agents_to_test = [
+            ("BackendAgent", "agenthub.agents.backend_agent"),
+            ("QAAgent", "agenthub.agents.qa_agent"),
+            ("UIGeneratorAgent", "agenthub.agents.ui_generator_agent"),
+            ("DataAnalystAgent", "agenthub.agents.data_analyst_agent"),
+        ]
+
+        for agent_name, module_path in agents_to_test:
+            try:
+                module = __import__(module_path, fromlist=[agent_name])
+                agent_class = getattr(module, agent_name)
+                agent_instance = agent_class()
+                print(f"\N{check mark} {agent_name} loaded successfully")
+
+                # Test capabilities
+                if hasattr(agent_instance, 'get_capabilities'):
+                    caps = agent_instance.get_capabilities()
+                    print(f"   \N{clipboard} Actions: {caps.get('actions', [])}")
+
+            except Exception as e:
+                print(f"\N{cross mark} {agent_name} failed: {e}")
+
+        print("\n\N{bullseye} Setup verification complete!")
+        print("Ready to start the server with: python main.py")
+
+    except Exception as e:
+        print(f"\N{cross mark} Setup verification failed: {e}")
+
+
+if __name__ == "__main__":
+    asyncio.run(verify_setup())


### PR DESCRIPTION
## Summary
- load new UI generator and data analyst agents in `load_agents`
- expose all agents in `agenthub.agents.__init__`
- add `UIGeneratorAgent` wrapper
- update startup to call `load_agents`
- provide helper scripts for setup and API testing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'agenthub')*

------
https://chatgpt.com/codex/tasks/task_e_68856d9d421c83258a2d593b8141aa24