### PR TITLE
Register additional agents

### DIFF
--- a/back/main.py
+++ b/back/main.py
@@ -33,6 +33,9 @@ from workflow_engine.core.WorkflowEngine import AgentRegistry, EventBus, Workflo
 from agenthub.agents.backend_agent import BackendAgent
 from agenthub.agents.base_agent import BaseAgent
 from agenthub.agents.qa_agent import QAAgent
+from agenthub.agents.content_writer_agent import ContentWriterAgent
+from agenthub.agents.ui_component_generator import UIComponentGeneratorAgent
+from agenthub.agents.data_analyst_agent import DataAnalystAgent
 from agenthub.config import config
 from agenthub.orchestrator import orchestrator
 from workflow_engine.core.WorkflowEngine import EventBus
@@ -145,7 +148,13 @@ async def load_agents_from_registry():
         logger.error(f"❌ Error loading registry: {e}")
         return
 
-    agent_classes = {"BackendAgent": BackendAgent, "QAAgent": QAAgent}
+    agent_classes = {
+        "BackendAgent": BackendAgent,
+        "QAAgent": QAAgent,
+        "ContentWriterAgent": ContentWriterAgent,
+        "UIComponentGeneratorAgent": UIComponentGeneratorAgent,
+        "DataAnalystAgent": DataAnalystAgent,
+    }
 
     agents_loaded = 0
     for entry in data:

--- a/back/registry.json
+++ b/back/registry.json
@@ -8,5 +8,20 @@
     "id": "qa_agent",
     "class": "QAAgent",
     "config": {}
+  },
+  {
+    "id": "content_writer",
+    "class": "ContentWriterAgent",
+    "config": {}
+  },
+  {
+    "id": "ui_component_generator",
+    "class": "UIComponentGeneratorAgent",
+    "config": {}
+  },
+  {
+    "id": "data_analyst",
+    "class": "DataAnalystAgent",
+    "config": {}
   }
 ]

--- a/registry.json
+++ b/registry.json
@@ -6,5 +6,17 @@
   {
     "id": "qa_agent",
     "class": "QAAgent"
+  },
+  {
+    "id": "content_writer",
+    "class": "ContentWriterAgent"
+  },
+  {
+    "id": "ui_component_generator",
+    "class": "UIComponentGeneratorAgent"
+  },
+  {
+    "id": "data_analyst",
+    "class": "DataAnalystAgent"
   }
 ]


### PR DESCRIPTION
## Summary
- load new agent classes in `load_agents_from_registry`
- list ContentWriter, UIComponentGenerator and DataAnalyst agents in the registries

## Testing
- `python back/main.py` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pip install -r requirements.txt` *(fails: Could not fetch packages due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68856fe609d08325ae55520f2a1e5903