### PR TITLE
Enhance health endpoint metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,6 +551,7 @@ docker-compose up -d
 
 # Verificar servicios
 curl http://localhost:8000/health
+# El JSON incluye ahora los campos `disk_usage` y `memory_usage`
 curl http://localhost:3000
 ```
 

--- a/back/README.md
+++ b/back/README.md
@@ -198,6 +198,17 @@ Health check del sistema y agentes.
 ```json
 {
   "status": "ok",
+  "database": "healthy",
+  "disk_usage": {
+    "total": 1000000000,
+    "used": 500000000,
+    "free": 500000000
+  },
+  "memory_usage": {
+    "total": 8000000000,
+    "available": 4000000000,
+    "percent": 50.0
+  },
   "agents": {
     "backend_agent": {
       "healthy": true,
@@ -206,7 +217,7 @@ Health check del sistema y agentes.
     },
     "qa_agent": {
       "healthy": true,
-      "status": "idle", 
+      "status": "idle",
       "uptime": 3600.5
     }
   }

--- a/back/main.py
+++ b/back/main.py
@@ -10,10 +10,16 @@ load_dotenv()
 
 import json
 import logging
+import shutil
 from contextlib import asynccontextmanager
 from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+try:
+    import psutil  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    psutil = None
 
 try:
     import uvicorn  # type: ignore
@@ -298,12 +304,33 @@ async def health_check():
     except Exception as e:
         logger.error(f"Agent health check failed: {e}")
 
+    # Disk usage metrics
+    disk = shutil.disk_usage("/")
+    disk_usage = {
+        "total": disk.total,
+        "used": disk.used,
+        "free": disk.free,
+    }
+
+    # Memory usage metrics (if psutil available)
+    memory_usage = None
+    if psutil:
+        mem = psutil.virtual_memory()
+        memory_usage = {
+            "total": mem.total,
+            "available": mem.available,
+            "used": mem.used,
+            "percent": mem.percent,
+        }
+
     return {
         "status": "healthy" if db_status == "healthy" else "unhealthy",
         "message": "IOPeer Agent Hub is running",
         "version": "1.0.0",
         "database": db_status,
         "agents": agent_health,
+        "disk_usage": disk_usage,
+        "memory_usage": memory_usage,
         "total_agents": len(orchestrator.agent_registry.agents),
         "total_workflows": len(orchestrator.workflow_registry.workflows),
     }


### PR DESCRIPTION
## Summary
- expose disk and memory metrics in `/health`
- document new fields in README and backend docs

## Testing
- `pytest back/tests -q` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68856fe8f08483258783d04066d28ffb