### PR TITLE
Add global exception middleware

### DIFF
--- a/back/main.py
+++ b/back/main.py
@@ -26,6 +26,8 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 from sqlalchemy import text
 
+from .middleware import ExceptionMiddleware
+
 from workflow_engine import runtime as wf_runtime
 from workflow_engine.core.WorkflowEngine import AgentRegistry, EventBus, WorkflowEngine
 
@@ -203,6 +205,9 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Error handling middleware must be registered before routes
+app.add_middleware(ExceptionMiddleware)
 
 # Include auth routes
 app.include_router(auth_router, prefix="/auth", tags=["authentication"])

--- a/back/middleware.py
+++ b/back/middleware.py
@@ -1,0 +1,19 @@
+import logging
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware
+
+logger = logging.getLogger(__name__)
+
+class ExceptionMiddleware(BaseHTTPMiddleware):
+    """Catch exceptions during request processing and return JSON errors."""
+
+    async def dispatch(self, request: Request, call_next):
+        try:
+            return await call_next(request)
+        except Exception as exc:
+            logger.exception("Unhandled error: %s", exc)
+            return JSONResponse(
+                status_code=500,
+                content={"error": "Internal server error", "detail": str(exc)},
+            )


### PR DESCRIPTION
## Summary
- add custom HTTP middleware to catch and log exceptions
- register the middleware before routers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68856fe965e883258ba2d87a60915b84