### PR TITLE
Fix duplicate health endpoints

### DIFF
--- a/back/agenthub/main.py
+++ b/back/agenthub/main.py
@@ -234,8 +234,9 @@ async def root():
         "workflows": len(orchestrator.workflow_registry.workflows),
         "endpoints": [
             "/health",
+            "/health/extended",
             "/auth/signin",
-            "/auth/signup", 
+            "/auth/signup",
             "/auth/oauth/status",
             "/agents",
             "/message/send",
@@ -552,8 +553,8 @@ async def get_frontend_config():
     }
 
 # 6. Enhanced health check
-@app.get("/health")
-async def enhanced_health_check():
+@app.get("/health/extended")
+async def extended_health_check():
     """Comprehensive health check"""
     
     # Check database


### PR DESCRIPTION
## Summary
- expose an extended health check at `/health/extended`
- update root endpoint listing

## Testing
- `pytest tests/integration/test_api.py::TestAPI::test_health_check -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6885862690708325931b61feec2a9213