### PR TITLE
Update README for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,7 +536,16 @@ pip install -r requirements-dev.txt  # para producción usa requirements.txt
 
 # Ejecutar backend
 python -m agenthub.main
+```
 
+On Windows you can run:
+
+```cmd
+set PYTHONPATH=back && python -m agenthub.main
+```
+or run `make run` from Git Bash.
+
+```bash
 # Setup Frontend (nueva terminal)
 cd ../front
 npm install

--- a/back/README.md
+++ b/back/README.md
@@ -12,7 +12,7 @@ AgentHub is a lightweight framework for coordinating AI agents. It exposes a RES
 2. Create a Python 3.11 virtual environment and install the dependencies
    ```bash
    python3.11 -m venv venv
-   source venv/bin/activate
+   source venv/bin/activate  # Windows: venv\Scripts\activate
    pip install -r requirements-dev.txt
    ```
    You can also run `make install` if you have `make` available.
@@ -48,6 +48,11 @@ or
 ```bash
 python -m agenthub.main
 ```
+On Windows from the project root:
+```cmd
+set PYTHONPATH=back && python -m agenthub.main
+```
+You can also run `make run` from Git Bash.
 The interactive API documentation will be available at [http://localhost:8000/docs](http://localhost:8000/docs).
 
 ## CLI examples


### PR DESCRIPTION
## Summary
- clarify venv activation for Windows
- document how to run the backend on Windows via `PYTHONPATH` or `make`

## Testing
- `pytest -q back/tests` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68858627cf3c83258c0252c3902b66c0