### PR TITLE
Add wrapper for agenthub main entry

### DIFF
--- a/back/agenthub/main.py
+++ b/back/agenthub/main.py
@@ -1,0 +1,9 @@
+try:
+    from ..main import app, run_server
+except ImportError:  # pragma: no cover - fallback for direct execution
+    from main import app, run_server
+
+__all__ = ["app", "run_server"]
+
+if __name__ == "__main__":
+    run_server()


### PR DESCRIPTION
## Summary
- expose `app` and `run_server` from new `agenthub.main`
- fallback to absolute import when executed directly

## Testing
- `make run` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'agenthub')*

------
https://chatgpt.com/codex/tasks/task_e_68858b8ee3008325b23a78f05151fc58