### PR TITLE
Fix BaseAgent imports

### DIFF
--- a/back/agenthub/agents/api_documentator_agent.py
+++ b/back/agenthub/agents/api_documentator_agent.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict
 
-from agenthub.base_agent import BaseAgent
+from agenthub.agents.base_agent import BaseAgent
 
 
 class APIDocumentatorAgent(BaseAgent):

--- a/back/agenthub/agents/content_writer_agent.py
+++ b/back/agenthub/agents/content_writer_agent.py
@@ -7,7 +7,7 @@ import re
 from datetime import datetime
 from typing import Any, Dict, List
 
-from agenthub.base_agent import BaseAgent
+from agenthub.agents.base_agent import BaseAgent
 
 
 class ContentWriterAgent(BaseAgent):


### PR DESCRIPTION
## Summary
- fix imports for BaseAgent in API and content writer agents

## Testing
- `make lint` *(fails: flake8 missing)*
- `make test` *(fails: coverage plugin missing)*
- `pip install -r requirements-dev.txt` *(fails: cannot access pypi)*

------
https://chatgpt.com/codex/tasks/task_e_6886470db118832591d9e18f3c22dca5