### PR TITLE
Add agent types to loading

### DIFF
--- a/back/main.py
+++ b/back/main.py
@@ -31,6 +31,15 @@ from sqlalchemy import text
 from agenthub.agents.backend_agent import BackendAgent
 from agenthub.agents.base_agent import BaseAgent
 from agenthub.agents.qa_agent import QAAgent
+from agenthub.agents.content_writer_agent import ContentWriterAgent
+from agenthub.agents.ui_component_generator import UIComponentGeneratorAgent
+from agenthub.agents.data_analyst_agent import DataAnalystAgent
+from agenthub.agents.fastapi_generator_agent import FastAPIGeneratorAgent
+from agenthub.agents.database_architect_agent import DatabaseArchitectAgent
+from agenthub.agents.security_auditor_agent import SecurityAuditorAgent
+from agenthub.agents.test_generator_agent import TestGeneratorAgent
+from agenthub.agents.api_documentator_agent import APIDocumentatorAgent
+from agenthub.agents.ui_generator_agent import UIGeneratorAgent
 from agenthub.config import config
 from agenthub.orchestrator import orchestrator
 
@@ -173,8 +182,17 @@ async def load_agents_from_registry():
         return
 
     agent_classes = {
-        "BackendAgent": BackendAgent, 
-        "QAAgent": QAAgent
+        "BackendAgent": BackendAgent,
+        "QAAgent": QAAgent,
+        "ContentWriterAgent": ContentWriterAgent,
+        "UIComponentGeneratorAgent": UIComponentGeneratorAgent,
+        "DataAnalystAgent": DataAnalystAgent,
+        "FastAPIGeneratorAgent": FastAPIGeneratorAgent,
+        "DatabaseArchitectAgent": DatabaseArchitectAgent,
+        "SecurityAuditorAgent": SecurityAuditorAgent,
+        "TestGeneratorAgent": TestGeneratorAgent,
+        "APIDocumentatorAgent": APIDocumentatorAgent,
+        "UIGeneratorAgent": UIGeneratorAgent,
     }
 
     agents_loaded = 0

--- a/back/tests/unit/test_agent_loading.py
+++ b/back/tests/unit/test_agent_loading.py
@@ -1,0 +1,32 @@
+import asyncio
+import json
+from agenthub.orchestrator import orchestrator
+
+import back.main as main
+
+
+def test_load_agents_from_registry(tmp_path, monkeypatch):
+    registry = [
+        {"id": "backend_agent", "class": "BackendAgent"},
+        {"id": "qa_agent", "class": "QAAgent"},
+        {"id": "content_writer", "class": "ContentWriterAgent"},
+        {"id": "ui_component_generator", "class": "UIComponentGeneratorAgent"},
+        {"id": "data_analyst", "class": "DataAnalystAgent"},
+    ]
+
+    registry_file = tmp_path / "registry.json"
+    registry_file.write_text(json.dumps(registry))
+
+    monkeypatch.setitem(main.config.settings, "registry_file", str(registry_file))
+
+    orchestrator.agent_registry.agents.clear()
+
+    asyncio.run(main.load_agents_from_registry())
+
+    assert set(orchestrator.agent_registry.agents.keys()) == {
+        "backend_agent",
+        "qa_agent",
+        "content_writer",
+        "ui_component_generator",
+        "data_analyst",
+    }


### PR DESCRIPTION
## Summary
- import new agent classes in `back/main.py`
- register all available agent types in `load_agents_from_registry`
- add a unit test ensuring new agents load from a registry file

## Testing
- `pip install -q -r requirements-dev.txt` *(fails: Cannot connect to proxy)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'agenthub')*

------
https://chatgpt.com/codex/tasks/task_e_6886470de55c8325ab0776e84dbe578f