### PR TITLE
Fix duplicate BackendAgent import

### DIFF
--- a/back/agenthub/agents/__init__.py
+++ b/back/agenthub/agents/__init__.py
@@ -2,7 +2,6 @@ from agenthub.agents.backend_agent import BackendAgent
 from agenthub.agents.data_analyst_agent import DataAnalystAgent
 from agenthub.agents.qa_agent import QAAgent
 from agenthub.agents.ui_generator_agent import UIGeneratorAgent
-from agenthub.agents.backend_agent import BackendAgent
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- remove duplicate BackendAgent import from agenthub

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6886470e50708325b9329a55a3cd3c21