### PR TITLE
Make SECRET_KEY configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,6 +534,9 @@ python -m venv venv
 source venv/bin/activate  # Windows: venv\Scripts\activate
 pip install -r requirements-dev.txt  # para producción usa requirements.txt
 
+# Configurar clave secreta para JWT
+export AGENTHUB_SECRET_KEY="mi-clave-secreta"
+
 # Ejecutar backend
 python -m agenthub.main
 ```

--- a/back/README.md
+++ b/back/README.md
@@ -22,6 +22,12 @@ AgentHub is a lightweight framework for coordinating AI agents. It exposes a RES
    python -m agenthub.database.create_tables
    ```
 
+4. Configure the authentication secret key
+   ```bash
+   export AGENTHUB_SECRET_KEY="replace-me"
+   ```
+   Alternatively add `secret_key` to `config.yaml`. A development default is used if omitted.
+
 
 ## Running the server
 

--- a/back/agenthub/auth/utils.py
+++ b/back/agenthub/auth/utils.py
@@ -1,14 +1,21 @@
 """Utility functions for authentication."""
+
 from datetime import datetime, timedelta
+import os
 
 from fastapi import HTTPException, status
 from passlib.context import CryptContext
 from jose import jwt, JWTError
+from agenthub.config import config
 
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
-SECRET_KEY = "your-secret-key-change-in-production"
+# Load secret key from env or config with a sensible default
+SECRET_KEY = os.getenv(
+    "AGENTHUB_SECRET_KEY",
+    config.get("secret_key", "dev-secret-key"),
+)
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 30
 


### PR DESCRIPTION
## Summary
- pull JWT secret from `AGENTHUB_SECRET_KEY` or config file
- document new environment variable in backend README
- show example usage in root README

## Testing
- `make test` *(fails: unrecognized arguments --cov=agenthub)*

------
https://chatgpt.com/codex/tasks/task_e_6886470fe6648325a524467bb8404317