### PR TITLE
Remove manual print from DB connection

### DIFF
--- a/back/agenthub/database/connection.py
+++ b/back/agenthub/database/connection.py
@@ -24,7 +24,6 @@ def get_db():
     logger.info("Connecting to database")
     db = SessionLocal()
     try:
-        print("Conectando a la base de datos...")
         yield db
     finally:
         db.close()


### PR DESCRIPTION
## Summary
- rely solely on logger for connection messages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -r ../requirements-dev.txt` *(fails: could not find a version due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68864711c7588325b02ee4076402d8c3