### PR TITLE
Support sync agent handlers

### DIFF
--- a/back/tests/unit/workflow_engine/test_workflow_real_agents.py
+++ b/back/tests/unit/workflow_engine/test_workflow_real_agents.py
@@ -1,0 +1,44 @@
+import asyncio
+
+import sys
+
+sys.path.append("back")
+
+from agenthub.agents.backend_agent import BackendAgent
+from workflow_engine.core.WorkflowEngine import (
+    AgentRegistry,
+    Workflow,
+    WorkflowConnection,
+    WorkflowEngine,
+    WorkflowNode,
+    ConnectionType,
+    EventBus,
+)
+
+
+def test_simple_workflow_backend_agent():
+    registry = AgentRegistry()
+    bus = EventBus()
+    registry.register_agent("backend_agent", BackendAgent(), {})
+
+    wf = Workflow("wf_backend", "backend")
+    n1 = WorkflowNode("1", "backend_agent", {"action": "analyze_requirements"})
+    n2 = WorkflowNode("2", "backend_agent", {"action": "generate_crud"})
+    n2.inputs.append("1")
+    wf.nodes = {"1": n1, "2": n2}
+    wf.connections.append(WorkflowConnection("1", "2", ConnectionType.SUCCESS))
+
+    engine = WorkflowEngine(registry, bus)
+
+    initial_data = {
+        "requirements": "Simple API",
+        "model_name": "Item",
+        "operations": ["create"],
+    }
+
+    asyncio.run(engine.execute_workflow(wf, initial_data))
+
+    assert wf.nodes["1"].status.name == "COMPLETED"
+    assert wf.nodes["2"].status.name == "COMPLETED"
+    assert "crud_code" in wf.nodes["2"].result.get("data", {})
+

--- a/back/workflow_engine/core/WorkflowEngine.py
+++ b/back/workflow_engine/core/WorkflowEngine.py
@@ -218,13 +218,16 @@ class WorkflowExecution:
 
 
             # Ejecutar agente
-            result = await agent.handle(
-                {
-                    "action": node.config.get("action", "process"),
-                    "data": input_data,
-                    "config": node.config,
-                }
-            )
+            message = {
+                "action": node.config.get("action", "process"),
+                "data": input_data,
+                "config": node.config,
+            }
+
+            if asyncio.iscoroutinefunction(agent.handle):
+                result = await agent.handle(message)
+            else:
+                result = await asyncio.to_thread(agent.handle, message)
 
 
             # Guardar resultado


### PR DESCRIPTION
## Summary
- improve workflow engine to execute synchronous agent handlers without await
- add a test showing a simple workflow with the `BackendAgent`

## Testing
- `pre-commit run --files back/workflow_engine/core/WorkflowEngine.py back/tests/unit/workflow_engine/test_workflow_real_agents.py`
- `pytest back/tests/unit/workflow_engine/test_workflow_real_agents.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688664093da08325a75e0854eb9290c0