### PR TITLE
Ensure runtime event bus tracks WebSocket connections

### DIFF
--- a/back/main.py
+++ b/back/main.py
@@ -629,6 +629,8 @@ async def workflow_websocket(websocket: WebSocket, workflow_id: str):
     """WebSocket para updates en tiempo real de workflows"""
     await websocket.accept()
     workflow_runtime["websocket_connections"].append(websocket)
+    if workflow_runtime.get("event_bus"):
+        workflow_runtime["event_bus"].websocket_connections.append(websocket)
     
     try:
         logger.info(f"WebSocket connected for workflow: {workflow_id}")
@@ -656,6 +658,8 @@ async def workflow_websocket(websocket: WebSocket, workflow_id: str):
     finally:
         if websocket in workflow_runtime["websocket_connections"]:
             workflow_runtime["websocket_connections"].remove(websocket)
+        if workflow_runtime.get("event_bus") and websocket in workflow_runtime["event_bus"].websocket_connections:
+            workflow_runtime["event_bus"].websocket_connections.remove(websocket)
 
 # ============================================
 # ENDPOINTS ORIGINALES (mantenidos)


### PR DESCRIPTION
## Summary
- add incoming workflow WebSockets to the EventBus connection list
- remove sockets from EventBus list when clients disconnect

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'agenthub')*

------
https://chatgpt.com/codex/tasks/task_e_6886640a5050832599e22dce19c5dfb4