### PR TITLE
Fix duplicate workflow hook

### DIFF
--- a/front/src/hooks/useIopeer.js
+++ b/front/src/hooks/useIopeer.js
@@ -17,7 +17,6 @@ export const useIopeer = () => {
   const retryTimeoutRef = useRef(null);
 
   // Integrate workflow hook
-  const workflow = useWorkflow();
 
   const clearError = useCallback(() => {
     setError(null);


### PR DESCRIPTION
## Summary
- remove second `useWorkflow` declaration

## Testing
- `pip install -r requirements-dev.txt` *(fails: Could not connect)*
- `npm test --if-present` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68867789f934832584448934f3cb1a0b