### PR TITLE
Fix workflow editor canvas clearing

### DIFF
--- a/front/src/components/features/WorkflowEditor/WorkflowEditor.tsx
+++ b/front/src/components/features/WorkflowEditor/WorkflowEditor.tsx
@@ -10,8 +10,7 @@ import {
   Database,
   BarChart3,
   Code,
-  Palette,
-  ArrowLeft
+  Palette
 } from 'lucide-react';
 import { useIopeer } from '../../../hooks/useIopeer';
 
@@ -258,7 +257,7 @@ const WorkflowEditor: React.FC<{ workflow?: any; onSave?: () => void }> = ({ wor
 
   // Limpiar canvas
   const clearCanvas = () => {
-    if (nodes.length > 0 && !confirm('¿Estás seguro de que quieres limpiar el canvas?')) {
+    if (nodes.length > 0 && !window.confirm('¿Estás seguro de que quieres limpiar el canvas?')) {
       return;
     }
     setNodes([]);


### PR DESCRIPTION
## Summary
- remove unused ArrowLeft icon
- use `window.confirm` to show confirmation dialog
- add newline at EOF

## Testing
- `bash ./back/scripts/test.sh` *(fails: Could not install dependencies)*
- `pre-commit run --files front/src/components/features/WorkflowEditor/WorkflowEditor.tsx` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688684b25bfc832593128d4b43dddaaf