### PR TITLE
Add agent interface to workflow hooks

### DIFF
--- a/front/src/components/features/WorkflowEditor/WorkflowEditor.tsx
+++ b/front/src/components/features/WorkflowEditor/WorkflowEditor.tsx
@@ -16,6 +16,7 @@ import {
 import { useIopeer } from '../../../hooks/useIopeer';
 
 import { workflowService } from '../../../services/workflowService';
+import type { Agent } from '../../../hooks/useWorkflow';
 
 // Tipos para el workflow
 interface WorkflowNode {
@@ -33,14 +34,7 @@ interface WorkflowConnection {
   connection_type: string;
 }
 
-interface AgentType {
-  id: string;
-  name: string;
-  description: string;
-  icon: string;
-  category: string;
-  color: string;
-}
+
 
 const WorkflowEditor: React.FC<{ workflow?: any; onSave?: () => void }> = ({ workflow: initialWorkflow, onSave }) => {
   // Estado del workflow
@@ -52,7 +46,7 @@ const WorkflowEditor: React.FC<{ workflow?: any; onSave?: () => void }> = ({ wor
   
   // Estados de UI
   const [showAgentPanel, setShowAgentPanel] = useState(true);
-  const [draggedAgent, setDraggedAgent] = useState<AgentType | null>(null);
+  const [draggedAgent, setDraggedAgent] = useState<Agent | null>(null);
   const [saving, setSaving] = useState(false);
   const [isExecuting, setIsExecuting] = useState(false);
   const [executionProgress, setExecutionProgress] = useState<any>({});
@@ -91,7 +85,7 @@ const WorkflowEditor: React.FC<{ workflow?: any; onSave?: () => void }> = ({ wor
   }, [initialWorkflow]);
 
   // Convertir agentes disponibles a formato local
-  const agentsList: AgentType[] = Object.values(availableAgents).map(agent => ({
+  const agentsList: Agent[] = Object.values(availableAgents).map(agent => ({
     id: agent.id,
     name: agent.name || agent.id,
     description: agent.description || 'No description available',
@@ -227,7 +221,7 @@ const WorkflowEditor: React.FC<{ workflow?: any; onSave?: () => void }> = ({ wor
   }, [nodes, saveWorkflow, workflowName]);
 
   // Manejar drag & drop de agentes
-  const handleAgentDragStart = (agent: AgentType) => {
+  const handleAgentDragStart = (agent: Agent) => {
     setDraggedAgent(agent);
   };
 
@@ -326,7 +320,7 @@ const WorkflowEditor: React.FC<{ workflow?: any; onSave?: () => void }> = ({ wor
     }
     acc[category].push(agent);
     return acc;
-  }, {} as Record<string, AgentType[]>);
+  }, {} as Record<string, Agent[]>);
 
   return (
     <div className="flex h-screen bg-gray-50">

--- a/front/src/hooks/useWorkflow.ts
+++ b/front/src/hooks/useWorkflow.ts
@@ -1,6 +1,15 @@
 // src/hooks/useWorkflow.js - MEJORADO para conectar con las nuevas APIs
 import { useState, useEffect, useCallback, useRef } from 'react';
 
+export interface Agent {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  category: string;
+  color: string;
+}
+
 // Configuración de la API
 const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:8000';
 
@@ -121,7 +130,7 @@ class WorkflowAPIClient {
 export const useWorkflow = () => {
   // Estado principal
   const [workflows, setWorkflows] = useState([]);
-  const [availableAgents, setAvailableAgents] = useState({});
+  const [availableAgents, setAvailableAgents] = useState<Record<string, Agent>>({});
   const [templates, setTemplates] = useState({});
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -133,7 +142,7 @@ export const useWorkflow = () => {
 
   // Referencias
   const apiClient = useRef(new WorkflowAPIClient());
-  const wsConnection = useRef(null);
+  const wsConnection = useRef<WebSocket | null>(null);
 
   // Cargar datos iniciales
   useEffect(() => {
@@ -161,7 +170,7 @@ export const useWorkflow = () => {
   const loadAvailableAgents = useCallback(async () => {
     try {
       const response = await apiClient.current.getAvailableAgents();
-      setAvailableAgents(response.agents || {});
+      setAvailableAgents((response.agents || {}) as Record<string, Agent>);
     } catch (err) {
       console.error('Error loading available agents:', err);
     }


### PR DESCRIPTION
## Summary
- add `Agent` interface to `useWorkflow` hook
- type `availableAgents` using that interface
- update workflow editor to leverage new interface

## Testing
- `npx tsc --noEmit` *(fails: Unexpected token in UIGeneratorSection.jsx)*
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688684b345888325a959c44a193499bc