### PR TITLE
Fix workflow templates loader

### DIFF
--- a/front/src/pages/Workflows.jsx
+++ b/front/src/pages/Workflows.jsx
@@ -34,7 +34,7 @@ const Workflows = () => {
     executeWorkflow: execute,
     createWorkflowFromTemplate: createFromTemplate,
     loadWorkflows,
-    loadWorkflowTemplates: loadTemplates,
+    loadTemplates,
     clearWorkflowError: clearError
 
   } = useIopeer();


### PR DESCRIPTION
## Summary
- fix Workflows page to use existing `loadTemplates` hook

## Testing
- `make test` *(fails: unrecognized arguments --cov=agenthub)*

------
https://chatgpt.com/codex/tasks/task_e_68868e732f788325851f76126d07af3d