### PR TITLE
Add WebSocket URL env config

### DIFF
--- a/front/.env.example
+++ b/front/.env.example
@@ -1,0 +1,4 @@
+# Example environment configuration for AgentHub frontend
+REACT_APP_API_URL=http://localhost:8000
+# Base URL for WebSocket connections
+REACT_APP_WS_URL=ws://localhost:8000/ws

--- a/front/README.md
+++ b/front/README.md
@@ -239,18 +239,20 @@ npm test -- --coverage
 
 ### Variables de Entorno
 
-Las siguientes variables controlan la configuración del frontend. Al menos
-`REACT_APP_API_URL` es necesaria para que la aplicación conozca la URL base de la
-API.
+Las siguientes variables controlan la configuración del frontend.
+`REACT_APP_API_URL` y `REACT_APP_WS_URL` son necesarias para que la aplicación
+conozca la URL base de la API y del WebSocket.
 
 | Variable            | Descripción                                   |
 |---------------------|-----------------------------------------------|
 | `REACT_APP_API_URL` | URL base del backend utilizado por el frontend |
+| `REACT_APP_WS_URL`  | URL base para conexiones WebSocket             |
 
 #### Desarrollo
 ```bash
 REACT_APP_ENV=development
 REACT_APP_API_URL=http://localhost:8000
+REACT_APP_WS_URL=ws://localhost:8000/ws
 REACT_APP_DEBUG=true
 ```
 
@@ -258,6 +260,7 @@ REACT_APP_DEBUG=true
 ```bash
 REACT_APP_ENV=production
 REACT_APP_API_URL=https://api.agenthub.com
+REACT_APP_WS_URL=wss://api.agenthub.com/ws
 REACT_APP_DEBUG=false
 ```
 

--- a/front/src/services/workflowService.js
+++ b/front/src/services/workflowService.js
@@ -2,6 +2,7 @@
 // Servicio para manejar todas las operaciones de workflows
 
 const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:8000';
+const WS_BASE_URL = process.env.REACT_APP_WS_URL || 'ws://localhost:8000';
 
 class WorkflowService {
   constructor() {
@@ -189,7 +190,7 @@ class WorkflowService {
 
   // Crear conexión WebSocket para updates en tiempo real
   createWebSocketConnection(workflowId, onMessage, onError, onClose) {
-    const wsURL = `ws://localhost:8000/api/v1/workflows/${workflowId}/ws`;
+    const wsURL = `${WS_BASE_URL}/api/v1/workflows/${workflowId}/ws`;
     
     try {
       const socket = new WebSocket(wsURL);


### PR DESCRIPTION
## Summary
- add .env.example with WebSocket URL
- document `REACT_APP_WS_URL` in README
- pull WebSocket base URL from env in workflowService

## Testing
- `pre-commit run --files front/README.md front/src/services/workflowService.js front/.env.example` *(fails: pre-commit not installed)*
- `pytest` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688842a1cd4083259eba5980b9318def