### PR TITLE
Require JWT_SECRET env

### DIFF
--- a/back/.env.example
+++ b/back/.env.example
@@ -1,0 +1,17 @@
+# Example configuration for the backend
+# Copy this file to .env and fill in the required values
+
+# Google OAuth
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+# GitHub OAuth
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+
+# URLs
+FRONTEND_URL=http://localhost:3000
+BACKEND_URL=http://localhost:8000
+
+# JWT secret key for signing tokens. Replace with a strong random value
+# JWT_SECRET=your-super-secret

--- a/back/agenthub/auth/oauth_routes.py
+++ b/back/agenthub/auth/oauth_routes.py
@@ -25,7 +25,11 @@ GITHUB_CLIENT_ID = os.getenv("GITHUB_CLIENT_ID")
 GITHUB_CLIENT_SECRET = os.getenv("GITHUB_CLIENT_SECRET")
 FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost:3000")
 BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")
-JWT_SECRET = os.getenv("JWT_SECRET", "your-secret-key-change-in-production")
+JWT_SECRET = os.getenv("JWT_SECRET")
+if not JWT_SECRET:
+    raise RuntimeError(
+        "JWT_SECRET environment variable is not set. Configure it in your .env file."
+    )
 
 class OAuthUser(BaseModel):
     id: str


### PR DESCRIPTION
## Summary
- enforce JWT_SECRET during OAuth setup
- add example environment file for the backend

## Testing
- `pytest -q` *(fails: ModuleNotFoundError - missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688842a30fa8832595d9911bab39b476