### PR TITLE
Centralize sendMessage utility

### DIFF
--- a/front/src/api/agentClient.js
+++ b/front/src/api/agentClient.js
@@ -1,0 +1,43 @@
+const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:8000';
+
+export async function sendMessage(agentId, action, data = {}, options = {}) {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 30000);
+
+  const token = typeof localStorage !== 'undefined' ? localStorage.getItem('token') : null;
+  const headers = {
+    'Content-Type': 'application/json',
+    'X-Requested-With': 'XMLHttpRequest',
+    ...options.headers,
+  };
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+
+  try {
+    const response = await fetch(`${API_BASE_URL}/message/send`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ agent_id: agentId, action, data }),
+      signal: controller.signal,
+      ...options,
+    });
+
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.detail || errorData.message || `HTTP ${response.status}: ${response.statusText}`);
+    }
+
+    return await response.json();
+  } catch (error) {
+    clearTimeout(timeoutId);
+    if (error.name === 'AbortError') {
+      throw new Error('Request timeout - El servidor tardó demasiado en responder');
+    }
+    throw error;
+  }
+}
+
+export default { sendMessage };

--- a/front/src/hooks/useIopeer.js
+++ b/front/src/hooks/useIopeer.js
@@ -1,6 +1,7 @@
 // frontend/src/hooks/useIopeer.js - CORREGIDO
 import { useState, useEffect, useCallback, useRef } from 'react';
 import useWorkflow from './useWorkflow';
+import { sendMessage as agentSendMessage } from '../api/agentClient';
 
 const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:8000';
 
@@ -161,20 +162,8 @@ export const useIopeer = () => {
   }, [connect]); // Solo ejecutar una vez al montar
 
   const sendMessage = useCallback(async (agentId, action, data = {}) => {
-    try {
-      return await makeRequest('/message/send', {
-        method: 'POST',
-        body: JSON.stringify({
-          agent_id: agentId,
-          action: action,
-          data: data
-        })
-      });
-    } catch (error) {
-      console.error('Send message error:', error);
-      throw error;
-    }
-  }, [makeRequest]);
+    return agentSendMessage(agentId, action, data);
+  }, []);
 
   return {
     // States
@@ -268,26 +257,7 @@ export const useAgents = () => {
   }, [fetchAgents]);
 
   const sendMessage = useCallback(async (agentId, action, data) => {
-    try {
-      const response = await fetch(`${API_BASE_URL}/message/send`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          agent_id: agentId,
-          action: action,
-          data: data
-        })
-      });
-      
-      if (!response.ok) {
-        throw new Error(`Failed to send message: ${response.status}`);
-      }
-      
-      return await response.json();
-    } catch (err) {
-      console.error('Send message error:', err);
-      throw err;
-    }
+    return agentSendMessage(agentId, action, data);
   }, []);
 
   const getAgentDetails = useCallback(async (agentId) => {

--- a/front/src/services/iopeerAPI.js
+++ b/front/src/services/iopeerAPI.js
@@ -2,6 +2,7 @@
  * Iopeer API Service adaptado para AgentHub
  */
 
+import { sendMessage as agentSendMessage } from '../api/agentClient';
 const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:8000';
 
 class IopeerAPI {
@@ -67,14 +68,7 @@ class IopeerAPI {
   }
 
   async sendMessage(agentId, action, data = {}) {
-    return this.request('/message/send', {
-      method: 'POST',
-      body: JSON.stringify({
-        agent_id: agentId,
-        action,
-        data,
-      }),
-    });
+    return agentSendMessage(agentId, action, data);
   }
 
   // Workflows


### PR DESCRIPTION
## Summary
- create `agentClient.js` for unified message sending
- refactor `iopeerAPI` and `useIopeer` hooks to use this new utility

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688842a432a48325b2e8f5f87bd62b9d