### PR TITLE
Make auth secret configurable via env var

### DIFF
--- a/back/agenthub/auth/auth.py
+++ b/back/agenthub/auth/auth.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+import os
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import JSONResponse
@@ -15,7 +16,7 @@ router = APIRouter()
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
-SECRET_KEY = "your-secret-key-change-in-production"
+SECRET_KEY = os.getenv("AGENTHUB_SECRET_KEY", "dev-secret-key")
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 30
 

--- a/back/config.yaml
+++ b/back/config.yaml
@@ -6,6 +6,8 @@ host: "0.0.0.0"
 port: 8000
 debug: false
 log_level: "INFO"
+# Clave secreta para JWT (o usa la variable de entorno AGENTHUB_SECRET_KEY)
+secret_key: "dev-secret-key"
 
 # Configuración de workers
 max_workers: 4


### PR DESCRIPTION
## Summary
- load JWT secret from `AGENTHUB_SECRET_KEY` in `auth.py`
- document `secret_key` usage in `back/config.yaml`

## Testing
- `pytest back/tests -q` *(fails: ModuleNotFoundError - fastapi)*
- `pip install -r requirements-dev.txt` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688844d79d5c8325956d2010fc979881