### PR TITLE
Package backend for imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ install: ## Instalar dependencias del backend
 # 🧪 Backend - Tests y Linter
 # ======================
 test: ## Ejecutar tests del backend
-	@pytest tests/ -v --cov=agenthub
+	@PYTHONPATH=back pytest back/tests -v
 
 lint: ## Verificar código del backend
 	@flake8 back/agenthub

--- a/back/pyproject.toml
+++ b/back/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"

--- a/back/setup.py
+++ b/back/setup.py
@@ -4,8 +4,7 @@ from setuptools import find_packages, setup
 setup(
     name="agenthub",
     version="1.0.0",
-    package_dir={"": "agenthub"},
-    packages=find_packages("agenthub"),
+    packages=find_packages(exclude=("tests", "tests.*")),
     install_requires=[
         "fastapi>=0.104.1",
         "uvicorn[standard]>=0.24.0",

--- a/back/tests/unit/workflow_engine/test_sync_agent_workflow.py
+++ b/back/tests/unit/workflow_engine/test_sync_agent_workflow.py
@@ -1,7 +1,4 @@
 import asyncio
-import sys
-
-sys.path.append("back")
 from workflow_engine.core.WorkflowEngine import (
     AgentRegistry,
     Workflow,

--- a/back/tests/unit/workflow_engine/test_workflow_engine.py
+++ b/back/tests/unit/workflow_engine/test_workflow_engine.py
@@ -1,9 +1,6 @@
 import asyncio
-import sys
 
 import pytest
-
-sys.path.append("back")
 from workflow_engine.core.WorkflowEngine import (
     AgentRegistry,
     Workflow,

--- a/back/tests/unit/workflow_engine/test_workflow_real_agents.py
+++ b/back/tests/unit/workflow_engine/test_workflow_real_agents.py
@@ -1,9 +1,5 @@
 import asyncio
 
-import sys
-
-sys.path.append("back")
-
 from agenthub.agents.backend_agent import BackendAgent
 from workflow_engine.core.WorkflowEngine import (
     AgentRegistry,


### PR DESCRIPTION
## Summary
- set up setuptools backend package
- configure pyproject
- clean up Makefile test target
- import modules directly in workflow engine tests

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_688844db8c8883258361733fdacd1601