### PR TITLE
feat: add reusable async hook

### DIFF
--- a/front/src/hooks/useAsync.js
+++ b/front/src/hooks/useAsync.js
@@ -1,0 +1,40 @@
+import { useState, useCallback } from 'react';
+import ErrorService from '../services/errorService';
+
+/**
+ * Generic hook to handle async operations.
+ * @param {Function} asyncFunction - function that returns a promise.
+ * @param {Object} options
+ * @param {string} options.context - context string for error logging.
+ * @returns {{execute: Function, loading: boolean, error: any}}
+ */
+export const useAsync = (asyncFunction, { context } = {}) => {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const execute = useCallback(
+    async (...args) => {
+      setLoading(true);
+      setError(null);
+      try {
+        return await asyncFunction(...args);
+      } catch (err) {
+        const processedError = ErrorService.handleApiError
+          ? ErrorService.handleApiError(err, context)
+          : err;
+        if (ErrorService.logError) {
+          ErrorService.logError(err, context);
+        }
+        setError(processedError);
+        throw processedError;
+      } finally {
+        setLoading(false);
+      }
+    },
+    [asyncFunction, context]
+  );
+
+  return { execute, loading, error };
+};
+
+export default useAsync;

--- a/front/src/services/errorService.js
+++ b/front/src/services/errorService.js
@@ -5,7 +5,9 @@
 
 class ErrorService {
   static handleApiError(error, context = '') {
-    console.error(`[${context}] API Error:`, error);
+    if (process.env.NODE_ENV !== 'production') {
+      console.error(`[${context}] API Error:`, error);
+    }
     
     // Determinar tipo de error
     if (error.name === 'TypeError' && error.message.includes('fetch')) {
@@ -79,9 +81,10 @@ class ErrorService {
     // En producción, enviar a servicio de logging
     if (process.env.NODE_ENV === 'production') {
       // sendToLoggingService(errorLog);
+    } else {
+      // Solo mostrar en consola en desarrollo
+      console.error('Error Log:', errorLog);
     }
-    
-    console.error('Error Log:', errorLog);
     return errorLog;
   }
 }


### PR DESCRIPTION
## Summary
- add generic `useAsync` hook to manage loading and error state for async calls
- refactor `useAgents` and `useMarketplace` to use the shared hook
- centralize error reporting and silence console errors in production

## Testing
- `pre-commit run --files front/src/hooks/useAsync.js front/src/hooks/useAgents.js front/src/hooks/useMarketplace.js front/src/services/errorService.js` *(fails: unable to access pre-commit-hooks repo)*
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688eb3e1b9fc8325a975f4143e2bd2d8