### PR TITLE
refactor: extract agent creator config and unify field add

### DIFF
--- a/front/src/pages/AgentCreatorPage.jsx
+++ b/front/src/pages/AgentCreatorPage.jsx
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import LoadingSpinner from '../components/ui/LoadingSpinner';
 import ErrorDisplay from '../components/ui/ErrorDisplay';
 import { useAgentCreator } from '../hooks/useAgentCreator';
+import { AGENT_TEMPLATES, CAPABILITY_OPTIONS } from './agentCreatorConfig';
 
 const AgentCreatorPage = () => {
   const navigate = useNavigate();
@@ -20,108 +21,12 @@ const AgentCreatorPage = () => {
     test_cases: []
   });
 
-  const { 
-    createAgent, 
-    testAgent, 
-    loading, 
-    error, 
-    availableCapabilities,
-    agentTemplates 
+  const {
+    createAgent,
+    testAgent,
+    loading,
+    error
   } = useAgentCreator();
-
-  // Plantillas predefinidas de agentes
-  const AGENT_TEMPLATES = {
-    'data_processor': {
-      name: 'Procesador de Datos',
-      icon: '📊',
-      description: 'Agente para procesar y transformar datos',
-      inputs: ['raw_data', 'transformation_rules'],
-      outputs: ['processed_data', 'summary_stats'],
-      capabilities: ['data_processing', 'file_handling'],
-      category: 'analytics',
-      code_template: `
-class CustomDataProcessor(BaseAgent):
-    def handle(self, message):
-        raw_data = message.get("raw_data")
-        rules = message.get("transformation_rules", {})
-        
-        # Tu lógica aquí
-        processed_data = self.process_data(raw_data, rules)
-        
-        return {
-            "status": "success",
-            "processed_data": processed_data,
-            "summary_stats": self.generate_stats(processed_data)
-        }
-`
-    },
-    'content_creator': {
-      name: 'Creador de Contenido',
-      icon: '✍️',
-      description: 'Agente para generar contenido especializado',
-      inputs: ['topic', 'style', 'target_audience'],
-      outputs: ['generated_content', 'keywords', 'metadata'],
-      capabilities: ['ai_integration', 'content_generation'],
-      category: 'content',
-      code_template: `
-class CustomContentCreator(BaseAgent):
-    def handle(self, message):
-        topic = message.get("topic")
-        style = message.get("style", "professional")
-        audience = message.get("target_audience", "general")
-        
-        # Tu lógica aquí
-        content = self.generate_content(topic, style, audience)
-        
-        return {
-            "status": "success",
-            "generated_content": content,
-            "keywords": self.extract_keywords(content),
-            "metadata": {"word_count": len(content.split())}
-        }
-`
-    },
-    'api_integrator': {
-      name: 'Integrador de APIs',
-      icon: '🔗',
-      description: 'Agente para integrar servicios externos',
-      inputs: ['api_endpoint', 'request_data', 'auth_config'],
-      outputs: ['response_data', 'status_code', 'processed_result'],
-      capabilities: ['api_calls', 'web_scraping'],
-      category: 'integration',
-      code_template: `
-class CustomAPIIntegrator(BaseAgent):
-    def handle(self, message):
-        endpoint = message.get("api_endpoint")
-        data = message.get("request_data", {})
-        auth = message.get("auth_config", {})
-        
-        # Tu lógica aquí
-        response = self.make_api_call(endpoint, data, auth)
-        
-        return {
-            "status": "success",
-            "response_data": response,
-            "status_code": response.status_code,
-            "processed_result": self.process_response(response)
-        }
-`
-    }
-  };
-
-  const CAPABILITY_OPTIONS = [
-    { id: 'ai_integration', name: 'Integración IA', icon: '🧠' },
-    { id: 'data_processing', name: 'Procesamiento de Datos', icon: '📊' },
-    { id: 'api_calls', name: 'Llamadas API', icon: '🔗' },
-    { id: 'file_handling', name: 'Manejo de Archivos', icon: '📁' },
-    { id: 'database_access', name: 'Acceso a BD', icon: '🗄️' },
-    { id: 'web_scraping', name: 'Web Scraping', icon: '🕷️' },
-    { id: 'image_processing', name: 'Procesamiento de Imágenes', icon: '🖼️' },
-    { id: 'notification_sending', name: 'Envío de Notificaciones', icon: '📧' },
-    { id: 'content_generation', name: 'Generación de Contenido', icon: '✍️' },
-    { id: 'automation', name: 'Automatización', icon: '⚙️' }
-  ];
-
   const handleTemplateSelect = useCallback((templateKey) => {
     const template = AGENT_TEMPLATES[templateKey];
     setAgentConfig(prev => ({
@@ -137,22 +42,12 @@ class CustomAPIIntegrator(BaseAgent):
     setCurrentStep(2);
   }, []);
 
-  const addInput = useCallback(() => {
-    const newInput = prompt('Nombre del input:');
-    if (newInput) {
+  const addField = useCallback((type) => {
+    const fieldName = prompt(`Nombre del ${type === 'inputs' ? 'input' : 'output'}:`);
+    if (fieldName) {
       setAgentConfig(prev => ({
         ...prev,
-        inputs: [...prev.inputs, newInput]
-      }));
-    }
-  }, []);
-
-  const addOutput = useCallback(() => {
-    const newOutput = prompt('Nombre del output:');
-    if (newOutput) {
-      setAgentConfig(prev => ({
-        ...prev,
-        outputs: [...prev.outputs, newOutput]
+        [type]: [...prev[type], fieldName]
       }));
     }
   }, []);
@@ -411,7 +306,7 @@ class ${className}(BaseAgent):
                   <div className="flex items-center justify-between mb-3">
                     <label className="text-sm font-medium text-gray-700">Inputs (Entradas)</label>
                     <button
-                      onClick={addInput}
+                      onClick={() => addField('inputs')}
                       className="text-blue-600 hover:text-blue-800 text-sm font-medium"
                     >
                       + Agregar
@@ -441,7 +336,7 @@ class ${className}(BaseAgent):
                   <div className="flex items-center justify-between mb-3">
                     <label className="text-sm font-medium text-gray-700">Outputs (Salidas)</label>
                     <button
-                      onClick={addOutput}
+                      onClick={() => addField('outputs')}
                       className="text-blue-600 hover:text-blue-800 text-sm font-medium"
                     >
                       + Agregar

--- a/front/src/pages/agentCreatorConfig.js
+++ b/front/src/pages/agentCreatorConfig.js
@@ -1,0 +1,94 @@
+// src/pages/agentCreatorConfig.js
+
+export const AGENT_TEMPLATES = {
+  'data_processor': {
+    name: 'Procesador de Datos',
+    icon: '📊',
+    description: 'Agente para procesar y transformar datos',
+    inputs: ['raw_data', 'transformation_rules'],
+    outputs: ['processed_data', 'summary_stats'],
+    capabilities: ['data_processing', 'file_handling'],
+    category: 'analytics',
+    code_template: `
+class CustomDataProcessor(BaseAgent):
+    def handle(self, message):
+        raw_data = message.get("raw_data")
+        rules = message.get("transformation_rules", {})
+
+        # Tu lógica aquí
+        processed_data = self.process_data(raw_data, rules)
+
+        return {
+            "status": "success",
+            "processed_data": processed_data,
+            "summary_stats": self.generate_stats(processed_data)
+        }
+`
+  },
+  'content_creator': {
+    name: 'Creador de Contenido',
+    icon: '✍️',
+    description: 'Agente para generar contenido especializado',
+    inputs: ['topic', 'style', 'target_audience'],
+    outputs: ['generated_content', 'keywords', 'metadata'],
+    capabilities: ['ai_integration', 'content_generation'],
+    category: 'content',
+    code_template: `
+class CustomContentCreator(BaseAgent):
+    def handle(self, message):
+        topic = message.get("topic")
+        style = message.get("style", "professional")
+        audience = message.get("target_audience", "general")
+
+        # Tu lógica aquí
+        content = self.generate_content(topic, style, audience)
+
+        return {
+            "status": "success",
+            "generated_content": content,
+            "keywords": self.extract_keywords(content),
+            "metadata": {"word_count": len(content.split())}
+        }
+`
+  },
+  'api_integrator': {
+    name: 'Integrador de APIs',
+    icon: '🔗',
+    description: 'Agente para integrar servicios externos',
+    inputs: ['api_endpoint', 'request_data', 'auth_config'],
+    outputs: ['response_data', 'status_code', 'processed_result'],
+    capabilities: ['api_calls', 'web_scraping'],
+    category: 'integration',
+    code_template: `
+class CustomAPIIntegrator(BaseAgent):
+    def handle(self, message):
+        endpoint = message.get("api_endpoint")
+        data = message.get("request_data", {})
+        auth = message.get("auth_config", {})
+
+        # Tu lógica aquí
+        response = self.make_api_call(endpoint, data, auth)
+
+        return {
+            "status": "success",
+            "response_data": response,
+            "status_code": response.status_code,
+            "processed_result": self.process_response(response)
+        }
+`
+  }
+};
+
+export const CAPABILITY_OPTIONS = [
+  { id: 'ai_integration', name: 'Integración IA', icon: '🧠' },
+  { id: 'data_processing', name: 'Procesamiento de Datos', icon: '📊' },
+  { id: 'api_calls', name: 'Llamadas API', icon: '🔗' },
+  { id: 'file_handling', name: 'Manejo de Archivos', icon: '📁' },
+  { id: 'database_access', name: 'Acceso a BD', icon: '🗄️' },
+  { id: 'web_scraping', name: 'Web Scraping', icon: '🕷️' },
+  { id: 'image_processing', name: 'Procesamiento de Imágenes', icon: '🖼️' },
+  { id: 'notification_sending', name: 'Envío de Notificaciones', icon: '📧' },
+  { id: 'content_generation', name: 'Generación de Contenido', icon: '✍️' },
+  { id: 'automation', name: 'Automatización', icon: '⚙️' }
+];
+


### PR DESCRIPTION
## Summary
- extract agent templates and capability options to dedicated config file
- streamline adding inputs/outputs with generic addField function

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688eb3e08eec8325b6d0c2224daf2a2c