### PR TITLE
refactor: import hooks directly

### DIFF
--- a/front/src/components/features/Agents/Agents.jsx
+++ b/front/src/components/features/Agents/Agents.jsx
@@ -1,7 +1,7 @@
 // front/src/components/features/Agents/Agents.jsx - ACTUALIZADO CON CREAR AGENTE
 import React from 'react';
 import { Users, Plus, Activity, AlertCircle, RefreshCw, Brain } from 'lucide-react';
-import { useAgents } from '../../../hooks/useIopeer';
+import { useAgents } from '../../../hooks/useAgents';
 import LoadingSpinner, { AgentsLoadingState } from '../../ui/LoadingSpinner';
 import ErrorDisplay from '../../ui/ErrorDisplay';
 import { useNavigate } from 'react-router-dom';

--- a/front/src/components/features/Marketplace/Marketplace.jsx
+++ b/front/src/components/features/Marketplace/Marketplace.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { BookOpen, Search, Star, Download } from 'lucide-react';
-import { useMarketplace } from '../../../hooks/useIopeer';
+import { useMarketplace } from '../../../hooks/useMarketplace';
 import { MarketplaceLoadingState } from '../../ui/LoadingSpinner';
 import ErrorDisplay from '../../ui/ErrorDisplay';
 import { useNavigate } from 'react-router-dom';


### PR DESCRIPTION
## Summary
- update Agents component to import useAgents hook directly
- adjust Marketplace component to use dedicated useMarketplace hook

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ee72e7ec08325bda6ce84c1e97483