### PR TITLE
Fix useWorkflow effect dependencies

### DIFF
--- a/front/src/hooks/useWorkflow.ts
+++ b/front/src/hooks/useWorkflow.ts
@@ -159,7 +159,7 @@ export const useWorkflow = () => {
     loadWorkflows();
     loadAvailableAgents();
     loadTemplates();
-  }, []);
+  }, [loadWorkflows, loadAvailableAgents, loadTemplates]);
 
   // Función para cargar workflows
   const loadWorkflows = useCallback(async () => {


### PR DESCRIPTION
## Summary
- include loading callbacks in `useWorkflow` effect dependencies

## Testing
- `CI=true npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ee72bcee88325927dc26623eb485a