### PR TITLE
Fix agent typing and icon imports

### DIFF
--- a/front/src/components/features/WorkflowEditor/WorkflowEditor.tsx
+++ b/front/src/components/features/WorkflowEditor/WorkflowEditor.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useCallback, useEffect } from 'react';
-import { Zap, Database, BarChart3, Code, Palette } from 'lucide-react';
+import { Zap, Database, BarChart3, Code, Palette, Trash2 } from 'lucide-react';
 import { useIopeer } from '../../../hooks/useIopeer';
 
 import { workflowService } from '../../../services/workflowService';
@@ -75,14 +75,15 @@ const WorkflowEditor: React.FC<{ workflow?: any; onSave?: () => void }> = ({ wor
   }, [initialWorkflow]);
 
   // Convertir agentes disponibles a formato local
-  const agentsList: Agent[] = Object.values(availableAgents).map(agent => ({
-    id: agent.id,
-    name: agent.name || agent.id,
-    description: agent.description || 'No description available',
-    icon: agent.icon || '🤖',
-    category: agent.category || 'general',
-    color: agent.color || '#6b7280'
-  }));
+  const agentsList: Agent[] =
+    Object.values(availableAgents as Record<string, Agent>).map((agent: Agent): Agent => ({
+      id: agent.id,
+      name: agent.name || agent.id,
+      description: agent.description || 'No description available',
+      icon: agent.icon || '🤖',
+      category: agent.category || 'general',
+      color: agent.color || '#6b7280'
+    }));
 
   // Función para guardar workflow
   const saveWorkflow = useCallback(async () => {


### PR DESCRIPTION
## Summary
- import `Trash2` icon for node deletion controls
- cast `availableAgents` to `Record<string, Agent>` and return strongly typed agent objects

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install --legacy-peer-deps --no-progress` *(fails: 403 Forbidden while fetching @types/react)*

------
https://chatgpt.com/codex/tasks/task_e_688ee72c14d88325a83a01c2472766dd