### PR TITLE
chore: tidy Workflows imports

### DIFF
--- a/front/src/pages/Workflows.jsx
+++ b/front/src/pages/Workflows.jsx
@@ -1,18 +1,16 @@
 import React, { useState, useEffect } from 'react';
-import { 
-  Plus, 
-  Play, 
-  Edit, 
-  Trash2, 
-  Copy, 
-  Download,
+import {
+  Plus,
+  Play,
+  Edit,
+  Trash2,
+  Copy,
   Clock,
   Users,
   Zap,
   BarChart3,
   CheckCircle,
   XCircle,
-  AlertCircle,
   ArrowRight,
   FileText,
   Sparkles
@@ -30,12 +28,11 @@ const Workflows = () => {
     error,
     isExecuting,
     activeExecution,
-    createWorkflow: create,
-    executeWorkflow: execute,
+    executeWorkflow,
     createWorkflowFromTemplate: createFromTemplate,
     loadWorkflows,
     loadTemplates,
-    clearWorkflowError: clearError
+    clearWorkflowError
 
   } = useIopeer();
   const [currentView, setCurrentView] = useState('list'); // 'list', 'editor', 'templates'


### PR DESCRIPTION
## Summary
- simplify Workflows page imports and hooks

## Testing
- `npm install --legacy-peer-deps --no-audit --no-fund` (fails: ENOTEMPTY rename)
- `npm test -- --watchAll=false` (fails: react-scripts not found)


------
https://chatgpt.com/codex/tasks/task_e_688ee72ea6c883258e58d79c6a8ffcd7