### PR TITLE
fix workflow hook initialization order

### DIFF
--- a/front/src/hooks/useWorkflow.ts
+++ b/front/src/hooks/useWorkflow.ts
@@ -153,14 +153,6 @@ export const useWorkflow = () => {
   // Referencias
   const apiClient = useRef(new WorkflowAPIClient());
   const wsConnection = useRef<WebSocket | null>(null);
-
-  // Cargar datos iniciales
-  useEffect(() => {
-    loadWorkflows();
-    loadAvailableAgents();
-    loadTemplates();
-  }, [loadWorkflows, loadAvailableAgents, loadTemplates]);
-
   // Función para cargar workflows
   const loadWorkflows = useCallback(async () => {
     try {
@@ -195,6 +187,13 @@ export const useWorkflow = () => {
       console.error('Error loading templates:', err);
     }
   }, []);
+
+  // Cargar datos iniciales
+  useEffect(() => {
+    loadWorkflows();
+    loadAvailableAgents();
+    loadTemplates();
+  }, [loadWorkflows, loadAvailableAgents, loadTemplates]);
 
   // Crear workflow
   const createWorkflow = useCallback(async (workflowData) => {


### PR DESCRIPTION
## Summary
- ensure loadWorkflows, loadAvailableAgents and loadTemplates callbacks are defined before invoking via useEffect

## Testing
- `tsc -p front/tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_688eeba556c88325b4fee5f9a171400d