### PR TITLE
Handle missing JWT_SECRET with temporary secret

### DIFF
--- a/back/agenthub/auth/oauth_routes.py
+++ b/back/agenthub/auth/oauth_routes.py
@@ -30,9 +30,12 @@ FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost:3000")
 BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")
 JWT_SECRET = os.getenv("JWT_SECRET")
 if not JWT_SECRET:
-    raise RuntimeError(
-        "JWT_SECRET environment variable is not set. Configure it in your .env file."
+    import secrets
+
+    logger.warning(
+        "JWT_SECRET environment variable is not set. Using a temporary insecure secret."
     )
+    JWT_SECRET = secrets.token_urlsafe(32)
 
 
 def generate_jwt_token(user_data: dict) -> str:


### PR DESCRIPTION
## Summary
- avoid crash when `JWT_SECRET` env var missing by generating a temporary secret

## Testing
- `make test` *(fails: ImportError: cannot import name 'FastAPI' from 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_688eee6c00c08325957eb23ade48e705