### PR TITLE
Use centralized auth configuration

### DIFF
--- a/back/agenthub/auth/auth.py
+++ b/back/agenthub/auth/auth.py
@@ -1,8 +1,8 @@
-import os
 from datetime import datetime, timedelta
 
 from agenthub.schemas import SignInInput, TokenResponse
 from agenthub.utils import ACCESS_TOKEN_EXPIRE_MINUTES, ALGORITHM, SECRET_KEY
+# SECRET_KEY is sourced from the AGENTHUB_SECRET_KEY environment variable or config
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import JSONResponse
 from fastapi.security import OAuth2PasswordBearer
@@ -16,10 +16,6 @@ from ..models.user import User
 router = APIRouter()
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
-
-SECRET_KEY = os.getenv("AGENTHUB_SECRET_KEY", "dev-secret-key")
-ALGORITHM = "HS256"
-ACCESS_TOKEN_EXPIRE_MINUTES = 30
 
 
 # Dependency


### PR DESCRIPTION
## Summary
- remove local SECRET_KEY, ALGORITHM, ACCESS_TOKEN_EXPIRE_MINUTES constants
- clarify that SECRET_KEY is loaded from environment via `agenthub.utils`

## Testing
- `PYTHONPATH=. pytest tests/unit/auth/test_auth_routes.py tests/unit/auth/test_get_current_user.py` (fails: no such table: iopeer_users)
- `PYTHONPATH=. pytest tests/integration/test_auth_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_689c79bfc72c83258600f77d6cfc7f0c