### PR TITLE
Use UserCreate schema for signup endpoint

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -127,12 +127,20 @@ http://localhost:8000
 ### POST `/auth/signup`
 Registra un nuevo usuario en el sistema.
 
-**Request Body:**
+**Request Body (JSON):**
 ```json
 {
   "email": "usuario@ejemplo.com",
   "password": "contraseña123"
 }
+```
+
+Ejemplo con `curl`:
+
+```bash
+curl -X POST http://localhost:8000/auth/signup \
+  -H 'Content-Type: application/json' \
+  -d '{"email": "usuario@ejemplo.com", "password": "contraseña123"}'
 ```
 
 **Response (201):**

--- a/back/agenthub/auth/auth.py
+++ b/back/agenthub/auth/auth.py
@@ -1,7 +1,7 @@
 import os
 from datetime import datetime, timedelta
 
-from agenthub.schemas import SignInInput, TokenResponse
+from agenthub.schemas import SignInInput, TokenResponse, UserCreate
 from agenthub.utils import ACCESS_TOKEN_EXPIRE_MINUTES, ALGORITHM, SECRET_KEY
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import JSONResponse
@@ -46,13 +46,13 @@ def create_access_token(data: dict, expires_delta: timedelta | None = None):
 
 
 @router.post("/signup")
-def register(email: str, password: str, db: Session = Depends(get_db)):
-    user = db.query(User).filter(User.email == email).first()
-    if user:
+def register(user: UserCreate, db: Session = Depends(get_db)):
+    db_user = db.query(User).filter(User.email == user.email).first()
+    if db_user:
         raise HTTPException(status_code=400, detail="El email ya está registrado")
 
-    hashed_pw = pwd_context.hash(password)
-    new_user = User(email=email, hashed_password=hashed_pw)
+    hashed_pw = pwd_context.hash(user.password)
+    new_user = User(email=user.email, hashed_password=hashed_pw)
     db.add(new_user)
     db.commit()
     db.refresh(new_user)

--- a/front/src/api/auth.test.js
+++ b/front/src/api/auth.test.js
@@ -12,11 +12,15 @@ describe('auth api', () => {
     process.env.REACT_APP_API_URL = 'http://localhost:8000';
   });
 
-  test('signupRequest posts to /signup', async () => {
+  test('signupRequest posts JSON body to /signup', async () => {
     await signupRequest('a@b.com', 'x');
     expect(fetch).toHaveBeenCalledWith(
       'http://localhost:8000/auth/signup',
-      expect.objectContaining({ method: 'POST' })
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: 'a@b.com', password: 'x' })
+      })
     );
   });
 


### PR DESCRIPTION
## Summary
- Accept `UserCreate` schema in `/auth/signup` handler
- Send JSON body in signup front-end tests
- Document JSON payload for user registration

## Testing
- `pytest` *(fails: No module named 'agenthub')*
- `npm test` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c79c17ce48325ae590dd75957b85e