### PR TITLE
Use TokenResponse in signin endpoint and add tests

### DIFF
--- a/back/agenthub/auth/auth.py
+++ b/back/agenthub/auth/auth.py
@@ -4,12 +4,9 @@ from datetime import datetime, timedelta
 from agenthub.schemas import SignInInput, TokenResponse
 from agenthub.utils import ACCESS_TOKEN_EXPIRE_MINUTES, ALGORITHM, SECRET_KEY
 from fastapi import APIRouter, Depends, HTTPException, status
-from fastapi.responses import JSONResponse
-from fastapi.security import OAuth2PasswordBearer
 from jose import jwt
 from passlib.context import CryptContext
 from sqlalchemy.orm import Session
-
 from ..database.connection import SessionLocal
 from ..models.user import User
 
@@ -70,10 +67,8 @@ def signin(user: SignInInput, db: Session = Depends(get_db)):
 
     access_token = create_access_token(data={"sub": db_user.email})
 
-    return JSONResponse(
-        content={
-            "access_token": access_token,
-            "token_type": "bearer",
-            "user": {"id": db_user.id, "email": db_user.email},
-        }
+    return TokenResponse(
+        access_token=access_token,
+        token_type="bearer",
+        user={"id": db_user.id, "email": db_user.email},
     )

--- a/back/agenthub/schemas.py
+++ b/back/agenthub/schemas.py
@@ -28,11 +28,19 @@ class SignInInput(BaseModel):
     password: str
 
 
+class UserPublic(BaseModel):
+    """Minimal public user data returned in auth responses."""
+
+    id: int
+    email: EmailStr
+
+
 class TokenResponse(BaseModel):
     """Response returned after successful authentication."""
 
     access_token: str
     token_type: str = "bearer"
+    user: UserPublic
 
 
 class OAuthUser(BaseModel):
@@ -49,6 +57,7 @@ __all__ = [
     "UserCreate",
     "UserOut",
     "SignInInput",
+    "UserPublic",
     "TokenResponse",
     "OAuthUser",
 ]

--- a/back/tests/unit/auth/test_signin_response.py
+++ b/back/tests/unit/auth/test_signin_response.py
@@ -1,0 +1,57 @@
+import os
+from importlib import reload
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client(tmp_path):
+    """Create a TestClient with a temporary SQLite database."""
+
+    os.environ["DATABASE_URL"] = f"sqlite:///{tmp_path}/test.db"
+
+    import agenthub.database.connection as connection
+    reload(connection)
+
+    engine = connection.engine
+    SessionLocal = connection.SessionLocal
+
+    from agenthub.models.user import User
+
+    connection.Base.metadata.create_all(bind=engine)
+
+    import agenthub.auth.auth as auth_module
+    reload(auth_module)
+
+    pwd_context = auth_module.pwd_context
+    router = auth_module.router
+
+    # Create a user for authentication
+    db = SessionLocal()
+    user = User(email="user@example.com", hashed_password=pwd_context.hash("secret"))
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    db.close()
+
+    app = FastAPI()
+    app.include_router(router, prefix="/auth")
+
+    return TestClient(app), user
+
+
+def test_signin_returns_token_structure(client):
+    client, user = client
+
+    response = client.post(
+        "/auth/signin", json={"email": user.email, "password": "secret"}
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["token_type"] == "bearer"
+    assert isinstance(data["access_token"], str)
+    assert data["user"] == {"id": user.id, "email": user.email}


### PR DESCRIPTION
## Summary
- Return `TokenResponse` model instead of `JSONResponse` in `/signin`
- Extend `TokenResponse` schema to include user info
- Add unit test covering signin response structure

## Testing
- `PYTHONPATH=. pytest tests/unit/auth/test_signin_response.py -q`
- `PYTHONPATH=. pytest tests/unit/auth/test_get_current_user.py::test_get_current_user_success -q` *(fails: sqlite3.OperationalError: no such table: iopeer_users)*


------
https://chatgpt.com/codex/tasks/task_e_689c79c1fdf0832589dc46f691f8f661