### PR TITLE
Read CORS origins from config

### DIFF
--- a/back/config.yaml
+++ b/back/config.yaml
@@ -36,5 +36,7 @@ logging:
 # Configuración de seguridad
 security:
   api_key_required: false
-  cors_origins: ["*"]
+  cors_origins:
+    - "http://localhost:3000"
+    - "http://localhost:5173"
   rate_limit: 100  # requests per minute

--- a/back/main.py
+++ b/back/main.py
@@ -318,9 +318,18 @@ app = FastAPI(
 )
 
 # CORS middleware
+# CORS middleware configuration from config or environment variable
+cors_origins_env = os.getenv("AGENTHUB_CORS_ORIGINS")
+if cors_origins_env:
+    cors_origins = [origin.strip() for origin in cors_origins_env.split(",")]
+else:
+    cors_origins = config.get("security", {}).get("cors_origins", ["*"])
+    if isinstance(cors_origins, str):
+        cors_origins = [origin.strip() for origin in cors_origins.split(",")]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000"],
+    allow_origins=cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- load CORS origin list from configuration or environment variable
- document multiple CORS origins in config

## Testing
- `pre-commit run --files back/main.py back/config.yaml` *(fails: CalledProcessError: git fetch origin --tags, CONNECT tunnel failed 403)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'agenthub')*

------
https://chatgpt.com/codex/tasks/task_e_68a510e222348325ae31a5a46bda169b