### PR TITLE
Require AGENTHUB_SECRET_KEY environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,8 +534,8 @@ python -m venv venv
 source venv/bin/activate  # Windows: venv\Scripts\activate
 pip install -r requirements-dev.txt  # para producción usa requirements.txt
 
-# Configurar clave secreta para JWT
-export AGENTHUB_SECRET_KEY="mi-clave-secreta"
+# Configurar clave secreta para JWT (obligatorio)
+export AGENTHUB_SECRET_KEY="mi-clave-secreta"  # la app fallará si no se define
 
 # Ejecutar backend
 python -m agenthub.main

--- a/back/README.md
+++ b/back/README.md
@@ -26,7 +26,7 @@ AgentHub is a lightweight framework for coordinating AI agents. It exposes a RES
    ```bash
    export AGENTHUB_SECRET_KEY="replace-me"
    ```
-   Alternatively add `secret_key` to `config.yaml`. A development default is used if omitted.
+   The server will fail to start if this variable is not defined.
 
 
 ## Running the server

--- a/back/agenthub/auth/auth.py
+++ b/back/agenthub/auth/auth.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 
 from agenthub.schemas import SignInInput, TokenResponse, UserCreate
 from agenthub.utils import ACCESS_TOKEN_EXPIRE_MINUTES, ALGORITHM, SECRET_KEY
-# SECRET_KEY is sourced from the AGENTHUB_SECRET_KEY environment variable or config
+# SECRET_KEY is sourced from the required AGENTHUB_SECRET_KEY environment variable
 from fastapi import APIRouter, Depends, HTTPException, status
 from jose import jwt
 from passlib.context import CryptContext

--- a/back/agenthub/config.py
+++ b/back/agenthub/config.py
@@ -19,6 +19,7 @@ class Config:
         self.config_path = os.getenv("AGENTHUB_CONFIG", "config.yaml")
         self.settings = self._load_config()
         self._apply_defaults()
+        self._require_secret_key()
 
     def _load_config(self) -> Dict[str, Any]:
         """Carga configuración desde archivo YAML"""
@@ -71,6 +72,13 @@ class Config:
                     )
                 else:
                     self.settings[config_key] = env_value
+
+    def _require_secret_key(self) -> None:
+        """Ensure the secret key is provided via environment."""
+        secret = os.getenv("AGENTHUB_SECRET_KEY")
+        if not secret:
+            raise RuntimeError("Missing AGENTHUB_SECRET_KEY environment variable")
+        self.settings["secret_key"] = secret
 
     def get(self, key: str, default=None):
         """Obtiene valor de configuración"""

--- a/back/agenthub/utils.py
+++ b/back/agenthub/utils.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import logging.handlers
-import os
 from pathlib import Path
 
 from agenthub.config import config
@@ -13,7 +12,7 @@ from agenthub.config import config
 # Common constants
 # ---------------------------------------------------------------------------
 
-SECRET_KEY = os.getenv("AGENTHUB_SECRET_KEY", config.get("secret_key", "dev-secret-key"))
+SECRET_KEY = config["secret_key"]
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 30
 

--- a/back/config.yaml
+++ b/back/config.yaml
@@ -6,8 +6,8 @@ host: "0.0.0.0"
 port: 8000
 debug: false
 log_level: "INFO"
-# Clave secreta para JWT (o usa la variable de entorno AGENTHUB_SECRET_KEY)
-secret_key: "dev-secret-key"
+# Clave secreta para JWT - definir AGENTHUB_SECRET_KEY en el entorno
+# secret_key: ""
 
 # Configuración de workers
 max_workers: 4


### PR DESCRIPTION
## Summary
- require `AGENTHUB_SECRET_KEY` from environment during configuration
- remove default `secret_key` from `config.yaml`
- document environment variable setup in READMEs

## Testing
- `pre-commit run --files back/config.yaml back/agenthub/config.py back/agenthub/utils.py back/agenthub/auth/auth.py README.md back/README.md` *(failed: CalledProcessError: git fetch origin --tags, 403)*
- `AGENTHUB_SECRET_KEY=test PYTHONPATH=back pytest back/tests -q` *(failed: ImportError: cannot import name 'FastAPI' from 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68a510e27e6c8325839f7f72d1fa5449