### PR TITLE
Add workflow and auth tests with CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+      - name: Run backend tests
+        run: PYTHONPATH=back pytest back/tests -v
+
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install dependencies
+        working-directory: front
+        run: npm ci
+      - name: Run frontend tests
+        working-directory: front
+        run: npm test -- --watchAll=false

--- a/back/tests/integration/test_workflow_errors.py
+++ b/back/tests/integration/test_workflow_errors.py
@@ -1,0 +1,28 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from main import app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def test_duplicate_workflow_creation(client):
+    payload = {
+        "name": "simple",
+        "nodes": [
+            {"id": "n1", "agent_type": "backend_agent", "config": {"action": "analyze_requirements"}},
+        ],
+        "connections": [],
+    }
+    resp1 = client.post("/api/v1/workflows/create", json=payload)
+    assert resp1.status_code == 200
+    resp2 = client.post("/api/v1/workflows/create", json=payload)
+    assert resp2.status_code == 409
+
+
+def test_execute_nonexistent_workflow(client):
+    resp = client.post("/api/v1/workflows/does-not-exist/execute", json={"data": {}})
+    assert resp.status_code == 404

--- a/back/tests/unit/test_workflow_security_manager.py
+++ b/back/tests/unit/test_workflow_security_manager.py
@@ -1,0 +1,21 @@
+import pytest
+
+from security.workflow_security import WorkflowSecurityManager
+
+
+@pytest.mark.asyncio
+async def test_sanitizes_dangerous_config():
+    manager = WorkflowSecurityManager()
+    node = {"id": "n1", "config": {"system_commands": "rm -rf /", "safe": "ok"}}
+    sanitized = await manager._sanitize_node_config(node, "free")
+    assert "system_commands" not in sanitized["config"]
+    assert sanitized["config"]["safe"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_detects_malicious_pattern():
+    manager = WorkflowSecurityManager()
+    workflow = {"nodes": [{"id": "n1", "agent_type": "backend_agent", "config": {"cmd": "rm -rf /"}}]}
+    result = await manager.validate_workflow_security(workflow, "user1", "free")
+    assert result["is_valid"] is False
+    assert "Patrones maliciosos detectados" in result["errors"]

--- a/front/src/App.test.jsx
+++ b/front/src/App.test.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import App from './App';
+
+jest.mock('./hooks/useIopeer', () => ({
+  useIopeer: () => ({
+    connectionStatus: 'connected',
+    agents: [],
+    systemHealth: {},
+    loading: false,
+    error: null,
+    connect: jest.fn(),
+  }),
+}));
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+test('redirects unauthenticated users to login', async () => {
+  window.history.pushState({}, '', '/dashboard');
+  render(<App />);
+  expect(await screen.findByText(/Iopeer/i)).toBeInTheDocument();
+});
+
+test('allows access to protected route when authenticated', async () => {
+  localStorage.setItem('token', 'fake');
+  localStorage.setItem('user', JSON.stringify({ email: 'test@example.com' }));
+  window.history.pushState({}, '', '/dashboard');
+  render(<App />);
+  expect(await screen.findByText(/Dashboard/i)).toBeInTheDocument();
+});

--- a/front/src/context/AuthContext.test.jsx
+++ b/front/src/context/AuthContext.test.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { AuthProvider, useAuth } from './AuthContext';
+
+describe('AuthContext', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ access_token: 'token123', user: { id: 1 } }),
+      })
+    );
+  });
+
+  test('login stores token and user', async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+    await act(async () => {
+      await result.current.login('a@b.com', 'pass');
+    });
+    expect(result.current.isLoggedIn).toBe(true);
+    expect(localStorage.getItem('token')).toBe('token123');
+  });
+
+  test('logout clears auth state', () => {
+    const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+    act(() => {
+      result.current.logout();
+    });
+    expect(result.current.isLoggedIn).toBe(false);
+    expect(localStorage.getItem('token')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- test workflow security manager sanitization and malicious pattern detection
- cover duplicate creation and missing workflow execution errors
- add frontend tests for protected routes and auth context
- run backend and frontend tests via CI

## Testing
- `pre-commit run --files back/tests/unit/test_workflow_security_manager.py back/tests/integration/test_workflow_errors.py front/src/App.test.jsx front/src/context/AuthContext.test.jsx .github/workflows/ci.yml` (failed: CONNECT tunnel failed)
- `PYTHONPATH=back pytest back/tests -q` (failed: ImportError: cannot import name 'Depends' from 'fastapi')
- `npm ci` (failed: ERESOLVE could not resolve)


------
https://chatgpt.com/codex/tasks/task_e_68a510e6a2308325865a33cb1e9a81c5